### PR TITLE
feat(gateway): warm skill query-gateway service (infra-only)

### DIFF
--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -50,3 +50,4 @@ src/components/*
 !src/components/ui
 src/lib/*.ts
 !src/lib/utils.ts
+!src/lib/skill-gateway.ts

--- a/dashboard/src/lib/skill-gateway.ts
+++ b/dashboard/src/lib/skill-gateway.ts
@@ -1,0 +1,76 @@
+// Shared client for the Alhazen skill query gateway.
+//
+// The gateway is a warm Python service that imports each skill's CLI module once
+// and drives its existing main() in-process, returning the JSON the command
+// prints. This replaces the per-request `execFile('uv', ['run', 'python', ...])`
+// pattern in each skill's dashboard lib.ts.
+//
+// ADOPTION (one-line body swap, no call-site changes): a skill lib's existing
+//   async function runJobhunt(args: string[]) {
+//     const { stdout } = await execFileAsync('uv', ['run','python', SCRIPT, ...args]);
+//     return JSON.parse(stdout);
+//   }
+// becomes
+//   async function runJobhunt(args: string[]) { return runSkill('jobhunt', args); }
+//
+// Requires SKILL_GATEWAY_URL (set on the dashboard service in docker-compose.yml).
+
+const GATEWAY_URL = process.env.SKILL_GATEWAY_URL;
+
+export interface RunSkillOptions {
+  /** Script stem when a skill has multiple entrypoints (e.g. 'job_forager'). */
+  entrypoint?: string;
+  /** Per-command timeout in seconds (gateway default applies otherwise). */
+  timeout?: number;
+}
+
+interface GatewayResponse {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+  stderr?: string;
+  exit_code?: number;
+}
+
+/** True when SKILL_GATEWAY_URL is configured (lets libs fall back if not). */
+export function gatewayConfigured(): boolean {
+  return Boolean(GATEWAY_URL);
+}
+
+/**
+ * Run a skill command through the gateway and return the parsed JSON result —
+ * the same value the old `JSON.parse(stdout)` helpers returned.
+ */
+export async function runSkill(
+  skill: string,
+  argv: string[],
+  opts: RunSkillOptions = {},
+): Promise<unknown> {
+  if (!GATEWAY_URL) {
+    throw new Error('SKILL_GATEWAY_URL is not set — skill gateway not configured');
+  }
+
+  const res = await fetch(`${GATEWAY_URL}/run`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      skill,
+      argv,
+      entrypoint: opts.entrypoint,
+      timeout: opts.timeout,
+    }),
+  });
+
+  const label = `${skill} ${argv.join(' ')}`;
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`gateway [${label}] -> HTTP ${res.status}: ${text}`);
+  }
+
+  const payload = (await res.json()) as GatewayResponse;
+  if (!payload.ok) {
+    const detail = payload.stderr ? ` | ${payload.stderr.trim()}` : '';
+    throw new Error(`gateway [${label}] failed: ${payload.error ?? 'unknown error'}${detail}`);
+  }
+  return payload.result;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,31 @@ services:
     restart: "no"
 
   # ============================================
+  # Skill Query Gateway - warm Python service that runs skill commands
+  # ============================================
+  gateway:
+    build:
+      context: .
+      dockerfile: gateway/Dockerfile
+    container_name: alhazen-gateway
+    depends_on:
+      typedb:
+        condition: service_healthy
+    environment:
+      - TYPEDB_HOST=typedb
+      - TYPEDB_PORT=1729
+      - TYPEDB_DATABASE=alhazen_notebook
+      - QDRANT_HOST=qdrant
+      - QDRANT_PORT=6333
+    # Internal service — executes skill commands incl. writes. Bind to localhost
+    # only; other containers reach it via http://gateway:8900 on alhazen-network.
+    ports:
+      - "127.0.0.1:8900:8900"
+    restart: unless-stopped
+    networks:
+      - alhazen-network
+
+  # ============================================
   # Dashboard
   # ============================================
   dashboard:
@@ -80,6 +105,9 @@ services:
       - PROJECT_ROOT=/app
       - QDRANT_HOST=qdrant
       - QDRANT_PORT=6333
+      # Available for dashboard libs to adopt the gateway (see docs/gateway.md).
+      # Unused until a lib's runX() helper switches from execFile to runSkill().
+      - SKILL_GATEWAY_URL=http://gateway:8900
     volumes:
       - ${HOME}/.alhazen/cache:/root/.alhazen/cache:ro
     ports:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -205,3 +205,9 @@ cd dashboard && npm install && npm run dev
 ```
 
 For a full guide to building a new skill dashboard, see [`docs/dashboard-guide.md`](dashboard-guide.md).
+
+**Skill data access:** dashboard libs currently run skill commands by spawning
+`uv run python <skill>.py` per request. The [skill query gateway](gateway.md) is
+a warm Python service (`gateway` container) that runs those commands in-process
+instead; libs adopt it by swapping their `execFile` helper for
+`runSkill()` (`dashboard/src/lib/skill-gateway.ts`).

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -1,0 +1,88 @@
+# Skill Query Gateway
+
+A warm, long-lived Python service that runs skill CLI commands in-process, so the
+dashboard no longer spawns `uv run python <skill>.py` per request.
+
+## Why
+
+Every dashboard data request currently does:
+
+```ts
+execFileAsync('uv', ['run', 'python', SCRIPT, ...args]) // → JSON.parse(stdout)
+```
+
+Each call pays Python cold-start + uv resolution + a fresh TypeDB connection, and
+the dashboard image has to bundle uv + Python + the venv + **every skill's code**
+(~11 GB). The *contract* (`{skill, command, argv} → JSON`) is good; only the
+*transport* (subprocess-per-request) is the problem.
+
+The gateway keeps the contract and replaces the transport: it imports each skill
+module **once** and drives the skill's existing `main()` via a synthetic
+`sys.argv`, capturing the JSON the command prints. **No skill code changes** — it
+works because every skill follows the same `argparse → commands[cmd](args) →
+print(json.dumps(...))` shape over the shared root venv.
+
+## Design
+
+- `src/skillful_alhazen/gateway/dispatcher.py` — resolves a skill to its full
+  source dir (`local_skills/<skill>` or `skills/<skill>`), imports the entrypoint
+  module once (cached), then per call sets `sys.argv`, redirects stdout, runs
+  `main()`, catches `SystemExit`, and parses the printed JSON. A process-global
+  lock serializes invocations (`sys.argv`/`sys.stdout` are global).
+- `src/skillful_alhazen/gateway/app.py` — FastAPI: `GET /health`, `POST /run`.
+  Runs the dispatcher in a thread with a timeout so the loop stays responsive.
+- Runs as the `gateway` service (`gateway/Dockerfile`, `docker-compose.yml`) —
+  Python + skills, **no Node**. This is where the "run a skill" weight belongs.
+
+## HTTP contract
+
+```
+GET  /health → { "ok": true, "skills": ["agentic-memory", ...] }
+
+POST /run
+  body: { "skill": "jobhunt", "argv": ["list-pipeline", "--status", "active"],
+          "entrypoint": "jobhunt"?, "timeout": 120? }
+  200:  { "ok": true,  "result": <parsed JSON the command printed>,
+          "exit_code": 0, "stderr": "...", "entrypoint": "jobhunt" }
+  200:  { "ok": false, "error": "non-JSON stdout: ...", "raw": "...", "stderr": "..." }
+  404:  { "ok": false, "error": "unknown skill: 'nope'" }
+  504:  { "ok": false, "error": "command timed out after 120s" }
+```
+
+`entrypoint` is the script stem; it defaults to the skill's primary script
+(`skill.yaml` `cli:` or first of `scripts:`). Pass it for secondary scripts,
+e.g. jobhunt's `job_forager`.
+
+## Adopting it in a dashboard lib (future work)
+
+`dashboard/src/lib/skill-gateway.ts` exports `runSkill(skill, argv, opts?)`. A
+skill's `lib.ts` helper changes from a subprocess spawn to a one-liner:
+
+```ts
+// before
+async function runJobhunt(args: string[]) {
+  const { stdout } = await execFileAsync('uv', ['run','python', JOBHUNT_SCRIPT, ...args]);
+  return JSON.parse(stdout);
+}
+// after
+import { runSkill } from '@/lib/skill-gateway';
+async function runJobhunt(args: string[]) { return runSkill('jobhunt', args); }
+```
+
+Call sites (the exported `listPipeline()` etc.) don't change.
+
+> **Note:** for **external** skills (jobhunt, scientific-literature, coach,
+> dismech) the `lib.ts` source lives upstream — those edits must go to the
+> upstream repo, not `local_skills/`, or `make skills-update` will overwrite
+> them. See [`conventions.md`](conventions.md).
+
+The dashboard image can only drop Python **after every lib has migrated** to the
+gateway.
+
+## Limitations (v1)
+
+- Invocations serialize per process; long-running commands (scilit `search`/
+  `embed`, `fetch-pdf`, jobhunt foraging) are better left on the CLI path. A
+  future async/background-job endpoint can lift this.
+- A hung command holds the lock until the timeout. Single uvicorn worker by
+  design; scale by running multiple gateway replicas or, later, a worker pool.

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,0 +1,55 @@
+# Gateway Dockerfile for Skillful-Alhazen
+#
+# A warm Python service that imports skill CLI modules once and drives their
+# existing main() in-process. Unlike the dashboard image, this carries ONLY
+# Python + uv + the venv + the skills tree (no Node) — it is the container where
+# the polyglot "run a skill" weight legitimately lives.
+
+# ==============================================================================
+# Stage 1: Python base with uv
+# ==============================================================================
+FROM python:3.11-slim AS python-base
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:$PATH"
+
+# ==============================================================================
+# Stage 2: Install Python dependencies (cached on dep files only)
+# ==============================================================================
+FROM python-base AS deps
+WORKDIR /app
+COPY pyproject.toml uv.lock README.md ./
+# Source needed for the dynamic version (pyproject reads src/.../__init__.py)
+COPY src/skillful_alhazen/__init__.py ./src/skillful_alhazen/
+# Mirror the dashboard's proven extra set (skills' heavy semantic deps are
+# imported lazily inside commands) plus the gateway's own deps.
+RUN uv sync --extra typedb --extra skills --extra skilllog --extra qdrant --extra gateway --no-dev
+
+# ==============================================================================
+# Stage 3: Runtime
+# ==============================================================================
+FROM python-base AS runner
+WORKDIR /app
+
+COPY --from=deps /app/.venv /app/.venv
+COPY pyproject.toml uv.lock README.md ./
+# Full Python source + the skill trees the gateway imports at runtime.
+COPY src/ ./src/
+COPY skills/ ./skills/
+COPY local_skills/ ./local_skills/
+
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONUNBUFFERED=1
+ENV GATEWAY_HOST=0.0.0.0
+ENV GATEWAY_PORT=8900
+ENV TYPEDB_HOST=typedb
+ENV TYPEDB_PORT=1729
+ENV TYPEDB_DATABASE=alhazen_notebook
+
+EXPOSE 8900
+
+HEALTHCHECK --interval=10s --timeout=5s --retries=10 --start-period=20s \
+  CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8900/health').status==200 else 1)" || exit 1
+
+CMD ["python", "-m", "skillful_alhazen.gateway"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,11 @@ they-said-whaaa = [
 qdrant = [
     "qdrant-client>=1.14.0",
 ]
+gateway = [
+    "typedb-driver>=3.8.0",
+    "fastapi>=0.104.0",
+    "uvicorn>=0.24.0",
+]
 semantic = [
     "voyageai>=0.3.0",
     "qdrant-client>=1.14.0",
@@ -80,7 +85,7 @@ pipeline = [
     "sf-hamilton>=1.75.0",
 ]
 all = [
-    "skillful-alhazen[typedb,dev,skills,skilllog,semantic,pipeline]",
+    "skillful-alhazen[typedb,dev,skills,skilllog,semantic,pipeline,gateway]",
 ]
 
 [project.scripts]

--- a/src/skillful_alhazen/gateway/__init__.py
+++ b/src/skillful_alhazen/gateway/__init__.py
@@ -1,0 +1,13 @@
+"""Alhazen skill query gateway.
+
+A warm, long-lived service that imports each skill's CLI module once and drives
+its existing ``main()`` in-process via a synthetic ``sys.argv`` — replacing the
+dashboard's per-request ``uv run python <skill>.py`` subprocess spawning.
+
+The command contract is unchanged: every skill parses ``argv`` with argparse and
+prints a JSON object to stdout. The gateway captures that stdout and returns it.
+"""
+
+from .dispatcher import DispatchError, list_skills, run
+
+__all__ = ["DispatchError", "list_skills", "run"]

--- a/src/skillful_alhazen/gateway/__main__.py
+++ b/src/skillful_alhazen/gateway/__main__.py
@@ -1,0 +1,21 @@
+"""Run the gateway: ``python -m skillful_alhazen.gateway``."""
+
+from __future__ import annotations
+
+import os
+
+
+def main() -> None:
+    import uvicorn
+
+    uvicorn.run(
+        "skillful_alhazen.gateway.app:app",
+        host=os.getenv("GATEWAY_HOST", "0.0.0.0"),
+        port=int(os.getenv("GATEWAY_PORT", "8900")),
+        workers=1,  # single worker: invocations serialize on a process-global lock
+        log_level=os.getenv("GATEWAY_LOG_LEVEL", "info"),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/skillful_alhazen/gateway/app.py
+++ b/src/skillful_alhazen/gateway/app.py
@@ -1,0 +1,49 @@
+"""FastAPI surface for the skill query gateway.
+
+Internal service only — it executes skill commands (including writes), so it must
+be bound to the docker network / localhost and never exposed publicly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from . import dispatcher
+
+DEFAULT_TIMEOUT = float(os.getenv("GATEWAY_TIMEOUT", "120"))
+
+app = FastAPI(title="Alhazen Skill Gateway", version="0.1.0")
+
+
+class RunRequest(BaseModel):
+    skill: str
+    argv: list[str] = Field(default_factory=list)
+    entrypoint: str | None = None
+    timeout: float | None = None
+
+
+@app.get("/health")
+async def health() -> dict:
+    return {"ok": True, "skills": dispatcher.list_skills()}
+
+
+@app.post("/run")
+async def run(req: RunRequest):
+    timeout = req.timeout or DEFAULT_TIMEOUT
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(dispatcher.run, req.skill, req.argv, req.entrypoint),
+            timeout=timeout,
+        )
+    except dispatcher.DispatchError as exc:
+        return JSONResponse(status_code=404, content={"ok": False, "error": str(exc)})
+    except TimeoutError:
+        return JSONResponse(
+            status_code=504,
+            content={"ok": False, "error": f"command timed out after {timeout}s"},
+        )

--- a/src/skillful_alhazen/gateway/dispatcher.py
+++ b/src/skillful_alhazen/gateway/dispatcher.py
@@ -1,0 +1,162 @@
+"""In-process skill command dispatch.
+
+Every Alhazen skill CLI follows the same shape: argparse subparsers dispatch to
+``commands[args.command](args)`` and the command ``print(json.dumps(...))`` to
+stdout. So we can run any command without touching skill code: import the
+module once, set ``sys.argv``, capture stdout, call ``main()``, and parse the
+JSON it printed.
+
+Scripts are resolved from the *full* skill directory (``local_skills/<skill>``
+or ``skills/<skill>``) rather than the stripped ``.claude/skills`` copy, so any
+sibling resources a command reads (recipes, schema files) are present.
+
+Because ``sys.argv``/``sys.stdout`` are process-global, ``run`` serializes all
+invocations behind a single lock. The FastAPI layer runs it in a thread so the
+event loop stays responsive; a generous timeout guards long commands.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import sys
+import threading
+from pathlib import Path
+
+import yaml
+
+# dispatcher.py -> gateway -> skillful_alhazen -> src -> <repo root>
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_LOCAL_SKILLS = _REPO_ROOT / "local_skills"
+_SKILLS = _REPO_ROOT / "skills"
+
+_lock = threading.Lock()
+_module_cache: dict[tuple[str, str], object] = {}
+
+
+class DispatchError(Exception):
+    """Raised when a skill or entrypoint cannot be resolved."""
+
+
+def _skill_root(skill: str) -> Path:
+    """Resolve a skill name to its full source directory."""
+    for base in (_LOCAL_SKILLS, _SKILLS):
+        candidate = base / skill
+        if candidate.exists():
+            # resolve() follows the local_skills/<core-skill> -> ../skills symlink
+            return candidate.resolve()
+    raise DispatchError(f"unknown skill: {skill!r}")
+
+
+def _primary_entrypoint(skill: str, root: Path) -> str:
+    """Determine a skill's default script stem from its skill.yaml.
+
+    Handles both ``cli: agentic_memory.py`` and ``scripts: [jobhunt.py, ...]``.
+    Falls back to the skill name with dashes converted to underscores.
+    """
+    manifest = root / "skill.yaml"
+    if manifest.exists():
+        data = yaml.safe_load(manifest.read_text(encoding="utf-8")) or {}
+        if data.get("cli"):
+            return Path(data["cli"]).stem
+        scripts = data.get("scripts")
+        if isinstance(scripts, list) and scripts:
+            return Path(scripts[0]).stem
+    return skill.replace("-", "_")
+
+
+def list_skills() -> list[str]:
+    """List installed skills that expose a Python entrypoint."""
+    names: set[str] = set()
+    for base in (_LOCAL_SKILLS, _SKILLS):
+        if not base.exists():
+            continue
+        for d in base.iterdir():
+            if d.is_dir() and not d.name.startswith((".", "_")):
+                names.add(d.name)
+    return sorted(names)
+
+
+def _resolve_script(skill: str, entrypoint: str | None) -> tuple[str, Path]:
+    root = _skill_root(skill)
+    stem = entrypoint or _primary_entrypoint(skill, root)
+    script = root / f"{stem}.py"
+    if not script.exists():
+        raise DispatchError(f"entrypoint not found: {skill}/{stem}.py")
+    return stem, script
+
+
+def _load_module(skill: str, stem: str, script: Path):
+    key = (skill, stem)
+    module = _module_cache.get(key)
+    if module is None:
+        name = f"_gw_{skill.replace('-', '_')}_{stem}"
+        spec = importlib.util.spec_from_file_location(name, script)
+        if spec is None or spec.loader is None:
+            raise DispatchError(f"could not load module for {skill}/{stem}.py")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        _module_cache[key] = module
+    return module
+
+
+def _exit_code(exc: SystemExit) -> int:
+    if exc.code is None:
+        return 0
+    if isinstance(exc.code, int):
+        return exc.code
+    return 1  # sys.exit("message") — the message went to stderr
+
+
+def run(skill: str, argv: list[str], entrypoint: str | None = None) -> dict:
+    """Run a skill command and return its JSON result.
+
+    Returns a dict with: ok, skill, entrypoint, exit_code, result (parsed JSON
+    from stdout), error (JSON parse error, if any), raw (stdout when unparsable),
+    and stderr.
+    """
+    stem, script = _resolve_script(skill, entrypoint)
+
+    with _lock:
+        module = _load_module(skill, stem, script)
+        if not hasattr(module, "main"):
+            raise DispatchError(f"{skill}/{stem}.py defines no main()")
+
+        out, err = io.StringIO(), io.StringIO()
+        saved_argv = sys.argv
+        sys.argv = [str(script), *argv]
+        code = 0
+        try:
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                try:
+                    module.main()
+                except SystemExit as exc:
+                    code = _exit_code(exc)
+        finally:
+            sys.argv = saved_argv
+
+        raw = out.getvalue()
+        stderr = err.getvalue()
+
+    result = None
+    parse_error = None
+    if raw.strip():
+        try:
+            result = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            parse_error = f"non-JSON stdout: {exc}"
+
+    ok = parse_error is None
+    return {
+        "ok": ok,
+        "skill": skill,
+        "entrypoint": stem,
+        "exit_code": code,
+        "result": result,
+        "error": parse_error,
+        "raw": None if ok else raw,
+        "stderr": stderr,
+    }

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,0 +1,84 @@
+"""Tests for the skill query gateway dispatcher.
+
+Parity test (gateway output == direct CLI output) is skipped when TypeDB is not
+reachable, so the suite still runs in DB-less CI.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "src"))
+
+from skillful_alhazen.gateway import dispatcher  # noqa: E402
+
+
+def _typedb_up() -> bool:
+    try:
+        from typedb.driver import Credentials, DriverOptions, TypeDB
+
+        host = os.getenv("TYPEDB_HOST", "localhost")
+        port = os.getenv("TYPEDB_PORT", "1729")
+        driver = TypeDB.driver(
+            f"{host}:{port}",
+            Credentials(
+                os.getenv("TYPEDB_USERNAME", "admin"),
+                os.getenv("TYPEDB_PASSWORD", "password"),
+            ),
+            DriverOptions(is_tls_enabled=False),
+        )
+        driver.close()
+        return True
+    except Exception:
+        return False
+
+
+requires_db = pytest.mark.skipif(not _typedb_up(), reason="TypeDB not reachable")
+
+
+def test_list_skills_includes_core():
+    skills = dispatcher.list_skills()
+    assert "agentic-memory" in skills
+    assert "typedb-notebook" in skills
+
+
+def test_unknown_skill_raises():
+    with pytest.raises(dispatcher.DispatchError):
+        dispatcher.run("does-not-exist", ["whatever"])
+
+
+def test_unknown_entrypoint_raises():
+    with pytest.raises(dispatcher.DispatchError):
+        dispatcher.run("agentic-memory", ["x"], entrypoint="not_a_script")
+
+
+@requires_db
+def test_parity_with_direct_cli():
+    os.environ.setdefault("TYPEDB_DATABASE", "alhazen_notebook")
+
+    gw = dispatcher.run("agentic-memory", ["list-persons"])
+    assert gw["ok"] is True
+    assert gw["exit_code"] == 0
+
+    proc = subprocess.run(
+        ["uv", "run", "python",
+         str(REPO / "skills/agentic-memory/agentic_memory.py"), "list-persons"],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+    )
+    cli = json.loads(proc.stdout)
+    assert gw["result"] == cli
+
+
+@requires_db
+def test_warm_module_is_cached():
+    os.environ.setdefault("TYPEDB_DATABASE", "alhazen_notebook")
+    dispatcher.run("typedb-notebook", ["describe-schema"])
+    # Second call must reuse the cached module rather than re-importing.
+    assert ("typedb-notebook", "typedb_notebook") in dispatcher._module_cache

--- a/uv.lock
+++ b/uv.lock
@@ -735,6 +735,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.138.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/58/ff455d9fe47c60abadb34b9e05a304b1f05f5ab8000ac01565156b6f5e43/fastapi-0.138.0.tar.gz", hash = "sha256:d445a4877636ad191e7053e08c9bf98cb921a6756776848400bb773d1740c061", size = 419240, upload-time = "2026-06-20T01:18:05.259Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/ff/8496d9847a5fedae775eb49460722d3efaa80487854273e9647ae876218c/fastapi-0.138.0-py3-none-any.whl", hash = "sha256:b6f54fd1bd72c80b0f899f172c61a600f6f7af9b43d4d772a018f35624048cb0", size = 126779, upload-time = "2026-06-20T01:18:03.483Z" },
+]
+
+[[package]]
 name = "ffmpeg-python"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3458,6 +3474,7 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "beautifulsoup4" },
+    { name = "fastapi" },
     { name = "hdbscan" },
     { name = "matplotlib" },
     { name = "numpy" },
@@ -3472,6 +3489,7 @@ all = [
     { name = "tqdm" },
     { name = "typedb-driver" },
     { name = "umap-learn" },
+    { name = "uvicorn" },
     { name = "voyageai" },
 ]
 dev = [
@@ -3479,6 +3497,11 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+]
+gateway = [
+    { name = "fastapi" },
+    { name = "typedb-driver" },
+    { name = "uvicorn" },
 ]
 mcp = [
     { name = "mcp" },
@@ -3518,6 +3541,8 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.97.0" },
     { name = "beautifulsoup4", marker = "extra == 'all'", specifier = ">=4.12.0" },
     { name = "beautifulsoup4", marker = "extra == 'skills'", specifier = ">=4.12.0" },
+    { name = "fastapi", marker = "extra == 'all'", specifier = ">=0.104.0" },
+    { name = "fastapi", marker = "extra == 'gateway'", specifier = ">=0.104.0" },
     { name = "hdbscan", marker = "extra == 'all'", specifier = ">=0.8.39" },
     { name = "hdbscan", marker = "extra == 'semantic'", specifier = ">=0.8.39" },
     { name = "httpx", specifier = ">=0.25.0" },
@@ -3556,15 +3581,18 @@ requires-dist = [
     { name = "tqdm", marker = "extra == 'all'", specifier = ">=4.66.0" },
     { name = "tqdm", marker = "extra == 'skills'", specifier = ">=4.66.0" },
     { name = "typedb-driver", marker = "extra == 'all'", specifier = ">=3.8.0" },
+    { name = "typedb-driver", marker = "extra == 'gateway'", specifier = ">=3.8.0" },
     { name = "typedb-driver", marker = "extra == 'mcp'", specifier = ">=3.8.0" },
     { name = "typedb-driver", marker = "extra == 'typedb'", specifier = ">=3.8.0" },
     { name = "umap-learn", marker = "extra == 'all'", specifier = ">=0.5.0" },
     { name = "umap-learn", marker = "extra == 'semantic'", specifier = ">=0.5.0" },
+    { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.24.0" },
+    { name = "uvicorn", marker = "extra == 'gateway'", specifier = ">=0.24.0" },
     { name = "voyageai", marker = "extra == 'all'", specifier = ">=0.3.0" },
     { name = "voyageai", marker = "extra == 'semantic'", specifier = ">=0.3.0" },
     { name = "youtube-transcript-api", marker = "extra == 'they-said-whaaa'", specifier = ">=0.6" },
 ]
-provides-extras = ["all", "dev", "mcp", "pipeline", "qdrant", "semantic", "skilllog", "skills", "they-said-whaaa", "typedb"]
+provides-extras = ["all", "dev", "gateway", "mcp", "pipeline", "qdrant", "semantic", "skilllog", "skills", "they-said-whaaa", "typedb"]
 
 [[package]]
 name = "sniffio"
@@ -4040,8 +4068,8 @@ name = "uvicorn"
 version = "0.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "sys_platform != 'emscripten'" },
-    { name = "h11", marker = "sys_platform != 'emscripten'" },
+    { name = "click" },
+    { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
 wheels = [


### PR DESCRIPTION
## What

Adds a warm, long-lived **skill query gateway** — one Python service that imports each skill's CLI module once and drives its existing `main()` in-process (via synthetic `sys.argv`), returning the JSON the command prints. This replaces the dashboard's per-request `uv run python <skill>.py` subprocess spawning.

The command **contract is unchanged** (`{skill, command, argv} → JSON`); only the **transport** changes. Works with **zero skill-code changes** because every skill follows the same `argparse → commands[cmd](args) → print(json.dumps(...))` pattern over the shared root venv.

## Why

Today every dashboard data request pays Python cold-start + `uv` resolution + a fresh TypeDB connection, and the dashboard image must bundle uv + Python + the venv + **every skill's code** (~11 GB). The gateway moves that polyglot weight into a dedicated, slimmer service (no Node — **3 GB** image) and eliminates per-request cold-start.

## Scope (deliberately infra-only)

- ✅ Gateway service: `src/skillful_alhazen/gateway/` (dispatcher + FastAPI `app` + `__main__`)
- ✅ `gateway/Dockerfile` + `docker-compose.yml` `gateway` service; `SKILL_GATEWAY_URL` wired on the dashboard (unused until libs adopt)
- ✅ `dashboard/src/lib/skill-gateway.ts` — `runSkill()` helper (drop-in for the `execFile` helpers; **not yet wired into any lib**)
- ✅ `docs/gateway.md` + architecture cross-link; `tests/test_gateway.py`

**Not in this PR (follow-ups):** migrating `lib.ts` files (core in-repo *and* external/upstream) to `runSkill`; slimming the dashboard image (only safe once all libs migrate); an async endpoint for long-running commands. The dashboard keeps working unchanged via its existing `execFile` path — **no regression**.

## Verification

- `pytest tests/test_gateway.py` → 5 passed (incl. gateway-vs-direct-CLI parity, warm-cache)
- `gateway` container builds (3.06 GB) and reports **healthy**
- `GET /health` → `{ok:true, skills:[13]}`
- `POST /run` read parity **byte-identical** to direct CLI (`agentic-memory list-persons`)
- Write-command path verified via `create-entity --dry-run` (correct `insert` TypeQL, `--attr` parsed)
- Warm gateway call **67 ms** vs cold `uv run` **169 ms** (larger gap for heavier-import skills / in-container)
- Existing dashboard still serves HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)