### PR TITLE
feat(skills): guard skills-update against overwriting local edits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -676,6 +676,11 @@ skills-validate: ## Validate all resolved skills have SKILL.md with name: field
 		echo "$(RED)✗ Validation failed$(NC)"; exit 1; \
 	fi
 
+.PHONY: skills-check
+skills-check: ## Fail if any local_skills/ copy has edits not in upstream (guards skills-update)
+	@echo "$(BLUE)Checking local_skills/ against upstream...$(NC)"
+	@uv run python scripts/check_skills_upstream.py
+
 define SKILLS_INSTALL_PY
 import os, subprocess, sys, shutil
 from pathlib import Path
@@ -853,6 +858,12 @@ skills-install: ## Resolve skills-registry.yaml into local_skills/ (path: symlin
 
 .PHONY: skills-update
 skills-update: ## Re-resolve all skills from registry (re-links core, re-clones external) and redeploy
+	@if [ "$(FORCE)" != "1" ]; then \
+		uv run python scripts/check_skills_upstream.py || { \
+			echo "$(RED)✗ Aborting skills-update — local edits in local_skills/ would be lost.$(NC)"; \
+			echo "$(YELLOW)  Push the changes upstream, or run: FORCE=1 make skills-update$(NC)"; \
+			exit 1; }; \
+	fi
 	@echo "$(BLUE)Updating all skills...$(NC)"
 	@$(if $(SKILL_LIBRARY),ALHAZEN_SKILL_LIBRARY=$(SKILL_LIBRARY)) uv run python -c "$$SKILLS_UPDATE_PY"
 	$(MAKE) --no-print-directory deploy-claude

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -47,6 +47,24 @@ uv run python local_resources/skilllog/skill_logger.py file-slog-schema-gap \
   (commit `6b41acf` in alhazen-skill-examples). If a schema fails on `make build-db` with a
   syntax error near `sub attribute`, the upstream source likely still has 2.x syntax.
 
+### Safeguard: `make skills-check`
+
+`make skills-update` now runs `scripts/check_skills_upstream.py` first and
+**aborts if any `local_skills/` copy holds content not in upstream** — i.e. a
+file that differs (a likely local edit) or exists only locally. This prevents
+the re-clone from silently destroying an un-pushed fix.
+
+```bash
+make skills-check          # report drift; exits non-zero if any local edits at risk
+make skills-update         # blocked when skills-check fails
+FORCE=1 make skills-update # bypass the guard and overwrite local edits anyway
+```
+
+Being merely *behind* upstream (files only present upstream) is reported but does
+not block — the update simply refreshes them. When the check fails, push the edit
+upstream (so the copy matches), then re-run; or use `FORCE=1` if you intend to
+discard the local change.
+
 ## Dashboard Design Conventions
 
 - **Overview-first layout**: Main entity pages (investigations, systems) show a high-level orientation summary at the top. All detail sections are click-through — do not render full content inline.

--- a/scripts/check_skills_upstream.py
+++ b/scripts/check_skills_upstream.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Guard against local_skills/ edits being silently overwritten by skills-update.
+
+For every EXTERNAL skill in skills-registry.yaml (and skills-registry-local.yaml)
+this clones the skill's upstream at its pinned ref and compares the upstream
+subdir against the installed copy in local_skills/<name>/.
+
+`make skills-update` deletes and re-clones external skills, so any edit made
+directly in local_skills/ is lost. This check fails when the installed copy holds
+content that an update would DESTROY:
+
+  - "modified": a file exists in both but differs (a likely local edit)
+  - "local-only": a file exists only in local_skills/ (added locally)
+
+Being merely BEHIND upstream ("upstream-only" files) is reported but does NOT
+fail — pulling those is the whole point of an update and loses nothing.
+
+Exit code: 0 if no skill has modified/local-only content, 1 otherwise.
+
+Core skills (registry `path:` entries) are symlinks to in-repo sources and are
+skipped — they have no separate upstream to drift from.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+# Generated / environment artifacts that are never meaningful "local edits".
+IGNORE_DIRS = {
+    ".git", "__pycache__", ".venv", "node_modules", ".next", ".build",
+    ".pytest_cache", ".ruff_cache", ".mypy_cache", "dist", "build", ".turbo",
+}
+IGNORE_SUFFIXES = (".pyc", ".pyo", ".egg-info")
+IGNORE_NAMES = {".DS_Store", "uv.lock", "package-lock.json"}
+
+GREEN, RED, YELLOW, BLUE, NC = "\033[32m", "\033[31m", "\033[33m", "\033[34m", "\033[0m"
+
+
+def _ignored(rel: Path) -> bool:
+    if any(part in IGNORE_DIRS for part in rel.parts):
+        return True
+    if rel.name in IGNORE_NAMES:
+        return True
+    return rel.name.endswith(IGNORE_SUFFIXES)
+
+
+def _hash_tree(root: Path) -> dict[str, str]:
+    """Map relative-path -> sha256 for every non-ignored file under root."""
+    out: dict[str, str] = {}
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in IGNORE_DIRS]
+        for fn in filenames:
+            abs_path = Path(dirpath) / fn
+            rel = abs_path.relative_to(root)
+            if _ignored(rel):
+                continue
+            h = hashlib.sha256(abs_path.read_bytes()).hexdigest()
+            out[str(rel)] = h
+    return out
+
+
+def _load_skills() -> list[dict]:
+    skills: list[dict] = []
+    reg = Path("skills-registry.yaml")
+    if reg.exists():
+        skills += (yaml.safe_load(reg.read_text()) or {}).get("skills") or []
+    local_reg = Path("skills-registry-local.yaml")
+    if local_reg.exists():
+        skills += (yaml.safe_load(local_reg.read_text()) or {}).get("skills") or []
+    return skills
+
+
+def main() -> int:
+    reg = Path("skills-registry.yaml")
+    if not reg.exists():
+        print("No skills-registry.yaml found", file=sys.stderr)
+        return 0
+    cfg = yaml.safe_load(reg.read_text()) or {}
+    defaults = cfg.get("defaults") or {}
+    default_git = os.environ.get("ALHAZEN_SKILL_LIBRARY") or defaults.get("git", "")
+    default_ref = defaults.get("ref", "main")
+
+    skills = _load_skills()
+    clone_cache: dict[tuple[str, str], Path] = {}
+    tmp_root = Path(tempfile.mkdtemp(prefix="skills-check-"))
+    drifted: list[str] = []
+    behind: list[str] = []
+
+    try:
+        for skill in skills:
+            name = skill["name"]
+            if "path" in skill:
+                continue  # core/local symlink — no separate upstream
+            git_url = skill.get("git") or default_git
+            ref = skill.get("ref") or default_ref
+            subdir = skill.get("subdir", ".")
+            if not git_url:
+                print(f"{YELLOW}  ? {name}: no git URL and no defaults.git — skipped{NC}")
+                continue
+
+            local = Path("local_skills") / name
+            if not local.exists():
+                print(f"{YELLOW}  ? {name}: not installed in local_skills/ — skipped{NC}")
+                continue
+
+            key = (git_url, ref)
+            clone = clone_cache.get(key)
+            if clone is None:
+                clone = tmp_root / f"clone_{len(clone_cache)}"
+                try:
+                    subprocess.run(
+                        ["git", "clone", "--depth=1", "--branch", ref, git_url, str(clone)],
+                        check=True, capture_output=True,
+                    )
+                except subprocess.CalledProcessError as e:
+                    print(f"{RED}  ✗ {name}: failed to clone {git_url}@{ref}: "
+                          f"{e.stderr.decode()[:120]}{NC}")
+                    drifted.append(name)
+                    continue
+                clone_cache[key] = clone
+
+            upstream = clone / subdir if subdir != "." else clone
+            if not upstream.exists():
+                print(f"{RED}  ✗ {name}: subdir '{subdir}' not found in upstream{NC}")
+                drifted.append(name)
+                continue
+
+            local_h, up_h = _hash_tree(local), _hash_tree(upstream)
+            modified = sorted(p for p in local_h.keys() & up_h.keys() if local_h[p] != up_h[p])
+            local_only = sorted(local_h.keys() - up_h.keys())
+            upstream_only = sorted(up_h.keys() - local_h.keys())
+
+            if modified or local_only:
+                drifted.append(name)
+                print(f"{RED}  ✗ {name}: local content would be LOST on update{NC}")
+                for p in modified:
+                    print(f"      ~ modified:   {p}")
+                for p in local_only:
+                    print(f"      + local-only: {p}")
+                if upstream_only:
+                    print(f"      ({len(upstream_only)} file(s) also behind upstream)")
+            elif upstream_only:
+                behind.append(name)
+                print(f"{YELLOW}  ↑ {name}: behind upstream by {len(upstream_only)} "
+                      f"file(s) (safe to update){NC}")
+            else:
+                print(f"{GREEN}  ✓ {name}: matches upstream{NC}")
+    finally:
+        shutil.rmtree(tmp_root, ignore_errors=True)
+
+    print()
+    if drifted:
+        print(f"{RED}✗ Upstream check FAILED — local edits would be overwritten: "
+              f"{', '.join(drifted)}{NC}")
+        print(f"{RED}  Push these changes upstream first, or re-run with "
+              f"FORCE=1 to overwrite them.{NC}")
+        return 1
+    if behind:
+        print(f"{YELLOW}✓ No local edits at risk ({len(behind)} skill(s) behind "
+              f"upstream — update will refresh them).{NC}")
+    else:
+        print(f"{GREEN}✓ All external skills match upstream.{NC}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

`make skills-update` deletes and re-clones each external skill from upstream, so any fix made directly in `local_skills/` is silently destroyed. This adds a safeguard that **fails when the installed copy differs from upstream**, blocking the overwrite.

- **`scripts/check_skills_upstream.py`** — for every external (git) skill in `skills-registry.yaml` (+ `skills-registry-local.yaml`), clones the pinned `ref`, and diffs the upstream subdir against `local_skills/<name>/`. Fails when local content would be **lost**:
  - `modified` — a file exists in both but differs (likely a local edit)
  - `local-only` — a file exists only in `local_skills/`
  - Files only present *upstream* (merely behind) are reported but do **not** fail — updating just refreshes them.
  - Ignores generated artifacts (`.git`, `__pycache__`, `.venv`, `node_modules`, `uv.lock`, etc.). Core `path:` skills are symlinks and skipped.
- **`make skills-check`** — runs the check standalone.
- **`make skills-update`** — runs the check first and aborts on drift; **`FORCE=1 make skills-update`** bypasses.
- Documented in `docs/conventions.md`.

## Why

This exact gap just bit us: a one-line schema fix in `local_skills/mythras-gm/schema.tql` would have been wiped by the next `skills-update`. The convention "push external fixes upstream" was advisory; this makes it enforced.

## Verification

Run against the live tree (mythras-gm has an un-pushed local schema edit):

```
$ make skills-check
  ✓ scientific-literature: matches upstream
  ✓ jobhunt: matches upstream
  ✓ dismech-notebook: matches upstream
  ✓ literature-trends: matches upstream
  ✗ mythras-gm: local content would be LOST on update
      ~ modified:   schema.tql
  ✓ coach: matches upstream
✗ Upstream check FAILED — local edits would be overwritten: mythras-gm
make: *** [skills-check] Error 1
```

`make skills-update` aborts before re-cloning (local edit preserved); `FORCE=1 make skills-update` skips the guard. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)