### PR TITLE
fix(dashboard): enable the scilit embedding map in the container image

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -14,10 +14,17 @@ ENV PATH="/root/.local/bin:$PATH"
 # ==============================================================================
 FROM python-base AS python-deps
 WORKDIR /app
+# build-essential lets the semantic extra's compiled deps (hdbscan) build from
+# source when no wheel is available. This stage is discarded — the runtime image
+# only copies /app/.venv — so it does not bloat the final image.
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
 COPY pyproject.toml uv.lock README.md ./
 # Copy source for version detection (pyproject.toml uses dynamic version from __init__.py)
 COPY src/skillful_alhazen/__init__.py ./src/skillful_alhazen/
-RUN uv sync --extra typedb --extra skills --extra skilllog --extra qdrant --no-dev
+# semantic = umap-learn + hdbscan + numpy — required by the `map`/`cluster`
+# commands the dashboard's embedding-map view calls.
+RUN uv sync --extra typedb --extra skills --extra skilllog --extra qdrant --extra semantic --no-dev
 
 # ==============================================================================
 # Stage 2b: Generate skills-config.json from skills-registry.yaml
@@ -106,7 +113,9 @@ WORKDIR /app
 # Copy Python environment and project files
 COPY --from=python-deps /app/.venv /app/.venv
 COPY pyproject.toml uv.lock README.md ./
-COPY src/skillful_alhazen/__init__.py ./src/skillful_alhazen/
+# Full package — skill commands (embed/map/cluster) import skillful_alhazen.utils
+# (vector_store etc.), not just the version __init__.py.
+COPY src/ ./src/
 # Copy all skills so the loop below can discover them (symlinks in local_skills/ resolve
 # correctly once both trees are present in the container)
 COPY skills/ ./skills/


### PR DESCRIPTION
## What

The scilit dashboard's embedding-map view (`/scientific-literature/.../map`) shells out to `scientific_literature.py map`, which failed in the dashboard container for two reasons — both fixed in `dashboard/Dockerfile`:

1. **Missing ML deps** — `map`/`cluster` import `umap` + `hdbscan` + `numpy`, but the image synced only `typedb/skills/skilllog/qdrant`. Added `--extra semantic`, plus `build-essential` in the build stage so `hdbscan` compiles. The build stage is discarded (runtime copies only `.venv`), so the runtime image isn't bloated by the toolchain.
2. **Missing package** — the runtime stage copied only `src/skillful_alhazen/__init__.py`, so `skillful_alhazen.utils.vector_store` (imported by the embed/map/cluster path) was absent. Now copies the full `src/` tree.

## Verification (live, against restored corpora)

| Corpus | Map points |
|---|---|
| CAIS 2026 Papers | ✅ 60 (UMAP x/y + facets) |
| Hallmarks of aging | ✅ 308 |
| CAIS 2026 Demos | ⚠️ UMAP error — see below |

Each point returns `paper_id`, UMAP `x`/`y`, `cluster`, `title`, `year`, `facets`.

## Known follow-up (separate, upstream scilit)

CAIS Demos (45 papers, 39 embeddable) trips a UMAP small-N failure (`k >= N` in `simplicial_set_embedding`) — the `map` command uses default `n_neighbors` that exceed the dataset size. That's a robustness bug in `scientific_literature.py map` (should clamp `n_neighbors`/spectral init to N), fixable upstream in `alhazen-skill-examples`. The image fix here is what unblocks the map; the small-corpus edge case is independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)