### PR TITLE
feat(skills): source external skills from per-repo clones, mount into containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,8 @@ dist/
 
 # External skills (installed via skills-registry.yaml)
 local_skills/
+# Symlink-free staged skill tree (built by `make stage-skills`, mounted into containers)
+.skills-build/
 
 # Deployment secrets
 deploy/deploy.env

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ TYPEDB_SCHEMAS_DIR := $(PROJECT_ROOT)/local_resources/typedb
 LOCAL_SKILLS_DIR := $(PROJECT_ROOT)/local_skills
 SKILLS_REGISTRY := $(PROJECT_ROOT)/skills-registry.yaml
 SKILL_LIBRARY ?=  # override: make build-skills SKILL_LIBRARY=https://github.com/MyOrg/fork
+# Authoritative full git clones of external skill repos live here (one per repo).
+# local_skills/<skill> symlinks into <repo>/<subdir>. Override per machine.
+ALHAZEN_SKILL_SOURCES ?= $(HOME)/Documents/GitHub
+# Symlink-free copy of resolved skills, mounted read-only into containers.
+STAGED_SKILLS_DIR := $(PROJECT_ROOT)/.skills-build
 CLAUDE_AGENTS_DIR := $(PROJECT_ROOT)/.claude/agents
 AGENTS_REGISTRY := $(PROJECT_ROOT)/agents-registry.yaml
 
@@ -88,7 +93,7 @@ build-env: ## Install Python dependencies
 	@echo "$(GREEN)✓ Python dependencies installed$(NC)"
 
 .PHONY: build-skills
-build-skills: skills-install deploy-claude ## Resolve skills-registry.yaml → local_skills/ + wire .claude/skills/
+build-skills: skills-install deploy-claude stage-skills ## Resolve skills-registry.yaml → local_skills/ + wire .claude/skills/ + stage for containers
 	@echo "$(BLUE)Compiling schema map...$(NC)"
 	@uv run python scripts/compile_schema_map.py --registry $(SKILLS_REGISTRY)
 	@echo "$(GREEN)✓ Skills built$(NC)"
@@ -685,58 +690,61 @@ define SKILLS_INSTALL_PY
 import os, subprocess, sys, shutil
 from pathlib import Path
 import yaml
+def repo_name(url):
+    return url.rstrip('/').split('/')[-1].removesuffix('.git')
 registry = Path('skills-registry.yaml')
 if not registry.exists():
     print('No skills-registry.yaml found'); sys.exit(0)
 cfg = yaml.safe_load(registry.read_text()) or {}
 defaults = cfg.get('defaults') or {}
-# Allow env var or make-var override of the skill library URL
 skill_library = os.environ.get('ALHAZEN_SKILL_LIBRARY') or defaults.get('git', '')
 default_ref = defaults.get('ref', 'main')
+sources_root = Path(os.environ.get('ALHAZEN_SKILL_SOURCES') or os.path.expanduser('~/Documents/GitHub'))
 skills = list(cfg.get('skills') or [])
-# Merge local registry if present (private/client skills not committed to git)
 local_reg = Path('skills-registry-local.yaml')
 if local_reg.exists():
-    local_cfg = yaml.safe_load(local_reg.read_text()) or {}
-    skills.extend(local_cfg.get('skills') or [])
+    skills.extend((yaml.safe_load(local_reg.read_text()) or {}).get('skills') or [])
 if not skills:
     print('No skills registered in skills-registry.yaml'); sys.exit(0)
 local_skills = Path('local_skills'); local_skills.mkdir(exist_ok=True)
+sources_root.mkdir(parents=True, exist_ok=True)
+cloned = {}  # repo_name -> ref (guard against the same repo pinned at two refs)
 for skill in skills:
     name = skill['name']
     target = local_skills / name
     if 'path' in skill:
-        # Path skill: absolute paths symlink directly; relative paths get ../ prefix
+        # Core/local skill: symlink directly (absolute path, or ../ for in-repo)
         src = Path(skill['path'])
-        if target.is_symlink():
-            target.unlink()
-        elif target.exists():
-            print(f'  Skipping {name} (real directory exists at local_skills/{name})'); continue
+        if target.is_symlink(): target.unlink()
+        elif target.exists(): shutil.rmtree(target)
         link_target = str(src) if src.is_absolute() else f'../{src}'
         target.symlink_to(link_target)
-        kind = 'local' if src.is_absolute() else 'core'
-        print(f'  ✓ Linked ({kind}): {name}')
+        print(f"  ✓ Linked ({'local' if src.is_absolute() else 'core'}): {name}")
         continue
-    # External skill: clone from git
+    # External skill: one full clone per repo under sources_root; symlink the subdir.
     git_url = skill.get('git') or skill_library
     ref = skill.get('ref') or default_ref
     subdir = skill.get('subdir', '.')
     if not git_url:
         print(f'  ✗ No git URL for {name} and no defaults.git set', file=sys.stderr); continue
-    if target.exists() and not target.is_symlink():
-        print(f'  Skipping {name} (already installed -- run make skills-update to refresh)'); continue
-    if target.is_symlink():
-        target.unlink()
-    print(f'  Installing {name} from {git_url}@{ref}...')
-    tmp = local_skills / f'_tmp_{name}'
-    try:
-        subprocess.run(['git', 'clone', '--depth=1', '--branch', ref, git_url, str(tmp)], check=True, capture_output=True)
-        src = tmp / subdir if subdir != '.' else tmp; src.rename(target)
-        print(f'  ✓ Installed {name}')
-    except subprocess.CalledProcessError as e:
-        print(f'  ✗ Failed to install {name}: {e}', file=sys.stderr)
-    finally:
-        if tmp.exists(): shutil.rmtree(tmp, ignore_errors=True)
+    rn = repo_name(git_url)
+    if rn in cloned and cloned[rn] != ref:
+        print(f'  ✗ {name}: repo {rn} requested at refs {cloned[rn]} and {ref} -- unsupported', file=sys.stderr); continue
+    clone = sources_root / rn
+    if not (clone / '.git').exists():
+        print(f'  Cloning {rn} from {git_url}@{ref}...')
+        r = subprocess.run(['git', 'clone', git_url, str(clone)], capture_output=True, text=True)
+        if r.returncode:
+            print(f'  ✗ Failed to clone {rn}: {r.stderr.strip()[:140]}', file=sys.stderr); continue
+        subprocess.run(['git', '-C', str(clone), 'checkout', ref], capture_output=True, text=True)
+    cloned[rn] = ref
+    src = clone / subdir if subdir != '.' else clone
+    if not src.exists():
+        print(f'  ✗ Subdir not found in {rn}: {subdir}', file=sys.stderr); continue
+    if target.is_symlink(): target.unlink()
+    elif target.exists(): shutil.rmtree(target)  # migrate a leftover detached dir
+    target.symlink_to(str(src.resolve()))
+    print(f'  ✓ Linked (external): {name} -> {rn}/{subdir}')
 endef
 export SKILLS_INSTALL_PY
 
@@ -744,6 +752,10 @@ define SKILLS_UPDATE_PY
 import os, subprocess, sys, shutil
 from pathlib import Path
 import yaml
+def repo_name(url):
+    return url.rstrip('/').split('/')[-1].removesuffix('.git')
+def git(*args):
+    return subprocess.run(['git', *args], capture_output=True, text=True)
 registry = Path('skills-registry.yaml')
 if not registry.exists():
     print('No skills-registry.yaml found'); sys.exit(0)
@@ -751,52 +763,64 @@ cfg = yaml.safe_load(registry.read_text()) or {}
 defaults = cfg.get('defaults') or {}
 skill_library = os.environ.get('ALHAZEN_SKILL_LIBRARY') or defaults.get('git', '')
 default_ref = defaults.get('ref', 'main')
+sources_root = Path(os.environ.get('ALHAZEN_SKILL_SOURCES') or os.path.expanduser('~/Documents/GitHub'))
 skills = list(cfg.get('skills') or [])
-# Merge local registry if present (private/client skills not committed to git)
 local_reg = Path('skills-registry-local.yaml')
 if local_reg.exists():
-    local_cfg = yaml.safe_load(local_reg.read_text()) or {}
-    skills.extend(local_cfg.get('skills') or [])
+    skills.extend((yaml.safe_load(local_reg.read_text()) or {}).get('skills') or [])
 if not skills:
     print('No skills registered'); sys.exit(0)
 local_skills = Path('local_skills'); local_skills.mkdir(exist_ok=True)
+sources_root.mkdir(parents=True, exist_ok=True)
+# 1) Pull each unique external clone (ff-only; never touch a dirty working tree).
+pulled = set()
+for skill in skills:
+    if 'path' in skill: continue
+    git_url = skill.get('git') or skill_library
+    ref = skill.get('ref') or default_ref
+    if not git_url: continue
+    rn = repo_name(git_url)
+    if rn in pulled: continue
+    pulled.add(rn)
+    clone = sources_root / rn
+    if not (clone / '.git').exists():
+        print(f'  Cloning {rn}...')
+        r = git('clone', git_url, str(clone))
+        if r.returncode: print(f'  ✗ clone {rn} failed: {r.stderr.strip()[:120]}', file=sys.stderr); continue
+        git('-C', str(clone), 'checkout', ref); continue
+    if git('-C', str(clone), 'status', '--porcelain').stdout.strip():
+        print(f'  ⚠ {rn}: uncommitted changes -- skipping pull (your work is safe)'); continue
+    git('-C', str(clone), 'fetch', 'origin', ref)
+    r = git('-C', str(clone), 'pull', '--ff-only', 'origin', ref)
+    if r.returncode:
+        print(f'  ⚠ {rn}: pull --ff-only failed (diverged?) -- skipping. {r.stderr.strip()[:90]}')
+    else:
+        print(f'  ✓ Pulled {rn}')
+# 2) Re-link every skill (core/local path symlinks + external subdir symlinks).
 for skill in skills:
     name = skill['name']
     target = local_skills / name
     if 'path' in skill:
-        # Path skill: re-link (absolute paths symlink directly; relative get ../ prefix)
         src = Path(skill['path'])
         if target.is_symlink(): target.unlink()
         elif target.exists(): shutil.rmtree(target)
         link_target = str(src) if src.is_absolute() else f'../{src}'
         target.symlink_to(link_target)
-        kind = 'local' if src.is_absolute() else 'core'
-        print(f'  ✓ Re-linked ({kind}): {name}')
+        print(f"  ✓ Re-linked ({'local' if src.is_absolute() else 'core'}): {name}")
         continue
-    # External skill: re-clone from git
     git_url = skill.get('git') or skill_library
     ref = skill.get('ref') or default_ref
     subdir = skill.get('subdir', '.')
     if not git_url:
-        print(f'  ✗ No git URL for {name} and no defaults.git set', file=sys.stderr); continue
-    print(f'  Updating {name}...')
+        print(f'  ✗ No git URL for {name}', file=sys.stderr); continue
+    clone = sources_root / repo_name(git_url)
+    src = clone / subdir if subdir != '.' else clone
+    if not src.exists():
+        print(f'  ✗ Subdir not found for {name}: {subdir}', file=sys.stderr); continue
     if target.is_symlink(): target.unlink()
     elif target.exists(): shutil.rmtree(target)
-    tmp = local_skills / f'_tmp_{name}'
-    try:
-        subprocess.run(['git', 'clone', '--depth=1', '--branch', ref, git_url, str(tmp)], check=True, capture_output=True)
-        src = tmp / subdir if subdir != '.' else tmp
-        if not src.exists():
-            print(f'  ✗ Subdir not found in {name} clone: {subdir}', file=sys.stderr)
-        else:
-            src.rename(target)
-            print(f'  ✓ Updated {name}')
-    except subprocess.CalledProcessError as e:
-        print(f'  ✗ Failed to clone {name}: {e}', file=sys.stderr)
-    except Exception as e:
-        print(f'  ✗ Failed to install {name}: {e}', file=sys.stderr)
-    finally:
-        if tmp.exists(): shutil.rmtree(tmp, ignore_errors=True)
+    target.symlink_to(str(src.resolve()))
+    print(f'  ✓ Re-linked (external): {name}')
 endef
 export SKILLS_UPDATE_PY
 
@@ -853,8 +877,21 @@ export AGENTS_INSTALL_PY
 .PHONY: skills-install
 skills-install: ## Resolve skills-registry.yaml into local_skills/ (path: symlinks, git: clones)
 	@echo "$(BLUE)Resolving skills from registry...$(NC)"
-	@$(if $(SKILL_LIBRARY),ALHAZEN_SKILL_LIBRARY=$(SKILL_LIBRARY)) uv run python -c "$$SKILLS_INSTALL_PY"
+	@ALHAZEN_SKILL_SOURCES="$(ALHAZEN_SKILL_SOURCES)" $(if $(SKILL_LIBRARY),ALHAZEN_SKILL_LIBRARY=$(SKILL_LIBRARY)) uv run python -c "$$SKILLS_INSTALL_PY"
 	@echo "$(GREEN)✓ Skills resolved to local_skills/$(NC)"
+
+.PHONY: stage-skills
+stage-skills: ## Materialize a symlink-free skill tree into ./.skills-build for container mounts
+	@echo "$(BLUE)Staging skills into .skills-build/ ...$(NC)"
+	@rm -rf "$(STAGED_SKILLS_DIR)" && mkdir -p "$(STAGED_SKILLS_DIR)"
+	@for skill_dir in $(LOCAL_SKILLS_DIR)/*/; do \
+		[ -e "$$skill_dir" ] || continue; \
+		name=$$(basename "$$skill_dir"); \
+		cp -RL "$$skill_dir" "$(STAGED_SKILLS_DIR)/$$name" 2>/dev/null \
+			|| echo "  $(YELLOW)⚠ skipped $$name (broken link?)$(NC)"; \
+	done
+	@find "$(STAGED_SKILLS_DIR)" -type d \( -name __pycache__ -o -name .venv -o -name node_modules \) -prune -exec rm -rf {} + 2>/dev/null || true
+	@echo "$(GREEN)✓ Skills staged: $$(ls -1 $(STAGED_SKILLS_DIR) | wc -l | tr -d ' ')$(NC)"
 
 .PHONY: skills-update
 skills-update: ## Re-resolve all skills from registry (re-links core, re-clones external) and redeploy
@@ -865,8 +902,9 @@ skills-update: ## Re-resolve all skills from registry (re-links core, re-clones 
 			exit 1; }; \
 	fi
 	@echo "$(BLUE)Updating all skills...$(NC)"
-	@$(if $(SKILL_LIBRARY),ALHAZEN_SKILL_LIBRARY=$(SKILL_LIBRARY)) uv run python -c "$$SKILLS_UPDATE_PY"
+	@ALHAZEN_SKILL_SOURCES="$(ALHAZEN_SKILL_SOURCES)" $(if $(SKILL_LIBRARY),ALHAZEN_SKILL_LIBRARY=$(SKILL_LIBRARY)) uv run python -c "$$SKILLS_UPDATE_PY"
 	$(MAKE) --no-print-directory deploy-claude
+	$(MAKE) --no-print-directory stage-skills
 	@echo "$(GREEN)✓ All skills updated$(NC)"
 
 .PHONY: skills-sync

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -57,9 +57,11 @@ RUN cd dashboard && ELECTRON_SKIP_BINARY_DOWNLOAD=1 npm ci
 # they'll be overwritten by ln -sfn below)
 COPY dashboard/ ./dashboard/
 
-# Copy all skill dashboard code (broad copy picks up any skill with a dashboard/ subdir)
-COPY local_skills/ ./local_skills/
-COPY skills/ ./skills/
+# Skill code comes from the staged tree (.skills-build = real dirs of every
+# resolved skill, incl. core). local_skills/ itself is now out-of-repo symlinks
+# that Docker can't follow, so we copy the staged bundle instead.
+# Requires `make stage-skills` (run by build-skills) before `docker compose build`.
+COPY .skills-build/ ./local_skills/
 
 # Inject generated skills-config.json into the public dir
 COPY --from=skills-config-gen /app/skills-config.json ./dashboard/public/skills-config.json
@@ -116,10 +118,8 @@ COPY pyproject.toml uv.lock README.md ./
 # Full package — skill commands (embed/map/cluster) import skillful_alhazen.utils
 # (vector_store etc.), not just the version __init__.py.
 COPY src/ ./src/
-# Copy all skills so the loop below can discover them (symlinks in local_skills/ resolve
-# correctly once both trees are present in the container)
-COPY skills/ ./skills/
-COPY local_skills/ ./local_skills/
+# Skill code from the staged, symlink-free tree (real dirs of every skill).
+COPY .skills-build/ ./local_skills/
 COPY local_resources/ ./local_resources/
 # Auto-discover all skill Python scripts and wire them into .claude/skills/<skill>/
 # This replaces hard-coded COPY lines — new skills are picked up automatically.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,10 @@ services:
         condition: service_healthy
     volumes:
       - ./local_resources/typedb:/schema:ro
-      - ./local_skills:/local_skills:ro
+      # Staged, symlink-free skill tree (real dirs — bind mounts can't follow the
+      # out-of-repo symlinks in local_skills/). Also gives db_init a real
+      # alhazen-core to import.
+      - ./.skills-build:/skills:ro
       - ./scripts:/scripts:ro
     networks:
       - alhazen-network
@@ -55,11 +58,11 @@ services:
     entrypoint: ["/bin/bash", "-c"]
     command:
       - |
-        pip install typedb-driver -q
+        pip install 'typedb-driver==3.8.0' -q
         python /scripts/db_init.py \
           /schema/alhazen_notebook.tql \
           /schema/namespaces/*.tql \
-          /local_skills/*/schema.tql
+          /skills/*/schema.tql
     restart: "no"
 
   # ============================================
@@ -79,6 +82,11 @@ services:
       - TYPEDB_DATABASE=alhazen_notebook
       - QDRANT_HOST=qdrant
       - QDRANT_PORT=6333
+      - SKILL_ROOT=/app/skills-mounted
+    # Skill code is mounted (not baked): a skill update = re-stage + restart, no
+    # rebuild. SKILL_ROOT points the dispatcher at this mount.
+    volumes:
+      - ./.skills-build:/app/skills-mounted:ro
     # Internal service — executes skill commands incl. writes. Bind to localhost
     # only; other containers reach it via http://gateway:8900 on alhazen-network.
     ports:

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -34,13 +34,14 @@ WORKDIR /app
 
 COPY --from=deps /app/.venv /app/.venv
 COPY pyproject.toml uv.lock README.md ./
-# Full Python source + the skill trees the gateway imports at runtime.
+# Only the package is baked. Skill code is NOT copied — it is mounted at runtime
+# from the staged tree (compose mounts ./.skills-build at $SKILL_ROOT), so a skill
+# update is a re-stage + `docker compose restart gateway`, never an image rebuild.
 COPY src/ ./src/
-COPY skills/ ./skills/
-COPY local_skills/ ./local_skills/
 
 ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=1
+ENV SKILL_ROOT=/app/skills-mounted
 ENV GATEWAY_HOST=0.0.0.0
 ENV GATEWAY_PORT=8900
 ENV TYPEDB_HOST=typedb

--- a/scripts/check_skills_upstream.py
+++ b/scripts/check_skills_upstream.py
@@ -1,73 +1,44 @@
 #!/usr/bin/env python3
-"""Guard against local_skills/ edits being silently overwritten by skills-update.
+"""Guard against local skill edits being silently overwritten by skills-update.
 
-For every EXTERNAL skill in skills-registry.yaml (and skills-registry-local.yaml)
-this clones the skill's upstream at its pinned ref and compares the upstream
-subdir against the installed copy in local_skills/<name>/.
+External skills are symlinks into per-repo git clones under
+`$ALHAZEN_SKILL_SOURCES` (default `~/Documents/GitHub`). `make skills-update`
+pulls those clones (`--ff-only`). This check fails when a clone holds local work
+that a pull/overwrite would endanger:
 
-`make skills-update` deletes and re-clones external skills, so any edit made
-directly in local_skills/ is lost. This check fails when the installed copy holds
-content that an update would DESTROY:
+  - uncommitted changes (`git status --porcelain` non-empty), or
+  - commits ahead of `origin/<ref>` (committed but not pushed).
 
-  - "modified": a file exists in both but differs (a likely local edit)
-  - "local-only": a file exists only in local_skills/ (added locally)
+A clone that is merely BEHIND origin (no local work) is reported but does NOT
+fail — pulling it is the whole point of an update. The check distinguishes a
+real local edit from merely-stale, using git provenance instead of a content
+diff against a fresh clone.
 
-Being merely BEHIND upstream ("upstream-only" files) is reported but does NOT
-fail — pulling those is the whole point of an update and loses nothing.
-
-Exit code: 0 if no skill has modified/local-only content, 1 otherwise.
-
-Core skills (registry `path:` entries) are symlinks to in-repo sources and are
-skipped — they have no separate upstream to drift from.
+Exit 0 if every external clone is clean & pushed (or just behind); 1 otherwise.
+Core / `path:` skills are skipped — they have no separate upstream.
 """
 
 from __future__ import annotations
 
-import hashlib
 import os
-import shutil
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 import yaml
 
-# Generated / environment artifacts that are never meaningful "local edits".
-IGNORE_DIRS = {
-    ".git", "__pycache__", ".venv", "node_modules", ".next", ".build",
-    ".pytest_cache", ".ruff_cache", ".mypy_cache", "dist", "build", ".turbo",
-}
-IGNORE_SUFFIXES = (".pyc", ".pyo", ".egg-info")
-IGNORE_NAMES = {".DS_Store", "uv.lock", "package-lock.json"}
-
-GREEN, RED, YELLOW, BLUE, NC = "\033[32m", "\033[31m", "\033[33m", "\033[34m", "\033[0m"
+GREEN, RED, YELLOW, NC = "\033[32m", "\033[31m", "\033[33m", "\033[0m"
 
 
-def _ignored(rel: Path) -> bool:
-    if any(part in IGNORE_DIRS for part in rel.parts):
-        return True
-    if rel.name in IGNORE_NAMES:
-        return True
-    return rel.name.endswith(IGNORE_SUFFIXES)
+def repo_name(url: str) -> str:
+    return url.rstrip("/").split("/")[-1].removesuffix(".git")
 
 
-def _hash_tree(root: Path) -> dict[str, str]:
-    """Map relative-path -> sha256 for every non-ignored file under root."""
-    out: dict[str, str] = {}
-    for dirpath, dirnames, filenames in os.walk(root):
-        dirnames[:] = [d for d in dirnames if d not in IGNORE_DIRS]
-        for fn in filenames:
-            abs_path = Path(dirpath) / fn
-            rel = abs_path.relative_to(root)
-            if _ignored(rel):
-                continue
-            h = hashlib.sha256(abs_path.read_bytes()).hexdigest()
-            out[str(rel)] = h
-    return out
+def git(clone: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", "-C", str(clone), *args], capture_output=True, text=True)
 
 
-def _load_skills() -> list[dict]:
+def load_skills() -> list[dict]:
     skills: list[dict] = []
     reg = Path("skills-registry.yaml")
     if reg.exists():
@@ -87,87 +58,56 @@ def main() -> int:
     defaults = cfg.get("defaults") or {}
     default_git = os.environ.get("ALHAZEN_SKILL_LIBRARY") or defaults.get("git", "")
     default_ref = defaults.get("ref", "main")
+    sources_root = Path(
+        os.environ.get("ALHAZEN_SKILL_SOURCES") or os.path.expanduser("~/Documents/GitHub")
+    )
 
-    skills = _load_skills()
-    clone_cache: dict[tuple[str, str], Path] = {}
-    tmp_root = Path(tempfile.mkdtemp(prefix="skills-check-"))
+    # Group external skills by their backing clone (the examples repo backs several).
+    repos: dict[str, dict] = {}
+    for skill in load_skills():
+        if "path" in skill:
+            continue
+        url = skill.get("git") or default_git
+        if not url:
+            continue
+        rn = repo_name(url)
+        entry = repos.setdefault(rn, {"ref": skill.get("ref") or default_ref, "skills": []})
+        entry["skills"].append(skill["name"])
+
     drifted: list[str] = []
-    behind: list[str] = []
+    for rn, info in sorted(repos.items()):
+        clone = sources_root / rn
+        backs = ", ".join(sorted(info["skills"]))
+        ref = info["ref"]
+        if not (clone / ".git").exists():
+            print(f"{YELLOW}  ? {rn}: not cloned at {clone} — run make skills-install ({backs}){NC}")
+            continue
 
-    try:
-        for skill in skills:
-            name = skill["name"]
-            if "path" in skill:
-                continue  # core/local symlink — no separate upstream
-            git_url = skill.get("git") or default_git
-            ref = skill.get("ref") or default_ref
-            subdir = skill.get("subdir", ".")
-            if not git_url:
-                print(f"{YELLOW}  ? {name}: no git URL and no defaults.git — skipped{NC}")
-                continue
+        git(clone, "fetch", "origin", ref)  # best-effort; offline → ahead/behind may be stale
+        dirty = git(clone, "status", "--porcelain").stdout.strip()
+        lr = git(clone, "rev-list", "--left-right", "--count", f"origin/{ref}...HEAD").stdout.split()
+        behind = int(lr[0]) if len(lr) == 2 else 0
+        ahead = int(lr[1]) if len(lr) == 2 else 0
 
-            local = Path("local_skills") / name
-            if not local.exists():
-                print(f"{YELLOW}  ? {name}: not installed in local_skills/ — skipped{NC}")
-                continue
-
-            key = (git_url, ref)
-            clone = clone_cache.get(key)
-            if clone is None:
-                clone = tmp_root / f"clone_{len(clone_cache)}"
-                try:
-                    subprocess.run(
-                        ["git", "clone", "--depth=1", "--branch", ref, git_url, str(clone)],
-                        check=True, capture_output=True,
-                    )
-                except subprocess.CalledProcessError as e:
-                    print(f"{RED}  ✗ {name}: failed to clone {git_url}@{ref}: "
-                          f"{e.stderr.decode()[:120]}{NC}")
-                    drifted.append(name)
-                    continue
-                clone_cache[key] = clone
-
-            upstream = clone / subdir if subdir != "." else clone
-            if not upstream.exists():
-                print(f"{RED}  ✗ {name}: subdir '{subdir}' not found in upstream{NC}")
-                drifted.append(name)
-                continue
-
-            local_h, up_h = _hash_tree(local), _hash_tree(upstream)
-            modified = sorted(p for p in local_h.keys() & up_h.keys() if local_h[p] != up_h[p])
-            local_only = sorted(local_h.keys() - up_h.keys())
-            upstream_only = sorted(up_h.keys() - local_h.keys())
-
-            if modified or local_only:
-                drifted.append(name)
-                print(f"{RED}  ✗ {name}: local content would be LOST on update{NC}")
-                for p in modified:
-                    print(f"      ~ modified:   {p}")
-                for p in local_only:
-                    print(f"      + local-only: {p}")
-                if upstream_only:
-                    print(f"      ({len(upstream_only)} file(s) also behind upstream)")
-            elif upstream_only:
-                behind.append(name)
-                print(f"{YELLOW}  ↑ {name}: behind upstream by {len(upstream_only)} "
-                      f"file(s) (safe to update){NC}")
-            else:
-                print(f"{GREEN}  ✓ {name}: matches upstream{NC}")
-    finally:
-        shutil.rmtree(tmp_root, ignore_errors=True)
+        if dirty or ahead:
+            drifted.append(rn)
+            print(f"{RED}  ✗ {rn}: local work at risk ({backs}){NC}")
+            for line in dirty.splitlines()[:10]:
+                print(f"      ~ {line.strip()}")
+            if ahead:
+                print(f"      ↑ {ahead} commit(s) ahead of origin/{ref} (unpushed)")
+        elif behind:
+            print(f"{YELLOW}  ↑ {rn}: {behind} commit(s) behind origin/{ref} — safe to update ({backs}){NC}")
+        else:
+            print(f"{GREEN}  ✓ {rn}: clean & in sync ({backs}){NC}")
 
     print()
     if drifted:
-        print(f"{RED}✗ Upstream check FAILED — local edits would be overwritten: "
+        print(f"{RED}✗ Upstream check FAILED — uncommitted or unpushed work in: "
               f"{', '.join(drifted)}{NC}")
-        print(f"{RED}  Push these changes upstream first, or re-run with "
-              f"FORCE=1 to overwrite them.{NC}")
+        print(f"{RED}  Commit & push it from the clone, or re-run with FORCE=1 to overwrite.{NC}")
         return 1
-    if behind:
-        print(f"{YELLOW}✓ No local edits at risk ({len(behind)} skill(s) behind "
-              f"upstream — update will refresh them).{NC}")
-    else:
-        print(f"{GREEN}✓ All external skills match upstream.{NC}")
+    print(f"{GREEN}✓ All external skill clones are clean & pushed.{NC}")
     return 0
 
 

--- a/scripts/compile_schema_map.py
+++ b/scripts/compile_schema_map.py
@@ -121,7 +121,10 @@ def main():
         schema_skills[name] = {
             "namespace": namespace,
             "depends_on": depends_on,
-            "schema_path": str(schema_tql.relative_to(Path.cwd())) if schema_tql.is_relative_to(Path.cwd()) else str(schema_tql),
+            # Stable, machine-independent path via the local_skills symlink (which
+            # resolves to the source clone at load time). Never the resolved
+            # absolute path — that would hardcode a per-machine location.
+            "schema_path": f"local_skills/{name}/{schema_tql.name}",
         }
 
     if not schema_skills:

--- a/skills-registry.yaml
+++ b/skills-registry.yaml
@@ -100,11 +100,11 @@ schema_map:
   namespaces:
     aos:
       skill: agent-os
-      schema: skills/agent-os/schema.tql
+      schema: local_skills/agent-os/schema.tql
       depends_on: []
     nbmem:
       skill: agentic-memory
-      schema: skills/agentic-memory/schema.tql
+      schema: local_skills/agentic-memory/schema.tql
       depends_on: []
     coach:
       skill: coach
@@ -112,7 +112,7 @@ schema_map:
       depends_on: []
     dm:
       skill: curation-skill-builder
-      schema: skills/curation-skill-builder/schema.tql
+      schema: local_skills/curation-skill-builder/schema.tql
       depends_on: []
     jhunt:
       skill: jobhunt
@@ -128,6 +128,6 @@ schema_map:
       depends_on: []
     trec:
       skill: tech-recon
-      schema: skills/tech-recon/schema.tql
+      schema: local_skills/tech-recon/schema.tql
       depends_on:
       - scientific-literature

--- a/src/skillful_alhazen/gateway/dispatcher.py
+++ b/src/skillful_alhazen/gateway/dispatcher.py
@@ -21,6 +21,7 @@ import contextlib
 import importlib.util
 import io
 import json
+import os
 import sys
 import threading
 from pathlib import Path
@@ -29,8 +30,13 @@ import yaml
 
 # dispatcher.py -> gateway -> skillful_alhazen -> src -> <repo root>
 _REPO_ROOT = Path(__file__).resolve().parents[3]
-_LOCAL_SKILLS = _REPO_ROOT / "local_skills"
-_SKILLS = _REPO_ROOT / "skills"
+# Skill roots. In containers SKILL_ROOT points at the mounted, symlink-free
+# staged tree (.skills-build) and is used exclusively; on the host we fall back
+# to the in-repo local_skills (symlinks into the source clones) + skills.
+if os.environ.get("SKILL_ROOT"):
+    _SKILL_ROOTS = (Path(os.environ["SKILL_ROOT"]),)
+else:
+    _SKILL_ROOTS = (_REPO_ROOT / "local_skills", _REPO_ROOT / "skills")
 
 _lock = threading.Lock()
 _module_cache: dict[tuple[str, str], object] = {}
@@ -42,7 +48,7 @@ class DispatchError(Exception):
 
 def _skill_root(skill: str) -> Path:
     """Resolve a skill name to its full source directory."""
-    for base in (_LOCAL_SKILLS, _SKILLS):
+    for base in _SKILL_ROOTS:
         candidate = base / skill
         if candidate.exists():
             # resolve() follows the local_skills/<core-skill> -> ../skills symlink
@@ -70,7 +76,7 @@ def _primary_entrypoint(skill: str, root: Path) -> str:
 def list_skills() -> list[str]:
     """List installed skills that expose a Python entrypoint."""
     names: set[str] = set()
-    for base in (_LOCAL_SKILLS, _SKILLS):
+    for base in _SKILL_ROOTS:
         if not base.exists():
             continue
         for d in base.iterdir():


### PR DESCRIPTION
## Problem

External skills were detached `git clone --depth=1` copies in `local_skills/` with the `.git` stripped — no provenance, can't `git diff`/`push`, and `skills-update` deletes-and-re-clones them. That's why a skill fix had to be edited in a detached copy and hand-cloned elsewhere to push.

## Design

One **authoritative full clone per upstream repo** under `$ALHAZEN_SKILL_SOURCES` (default `~/Documents/GitHub`); `local_skills/<skill>` becomes a **symlink** into the clone's subdir (generalizing the existing `path:` mechanism `dismech` already uses). Containers can't follow out-of-repo symlinks, so they read skill code from a **mounted, symlink-free staged tree** (`.skills-build`) — the heavy image is built once, and a skill update is **re-stage + restart, no rebuild** (the keep-warm gateway payoff). Update / drift-check / escalate are now plain git.

## Changes

- **Makefile** — `SKILLS_INSTALL_PY` clones per-repo (dedup; the examples repo backs 4 skills) + symlinks; `SKILLS_UPDATE_PY` does `git fetch` + `pull --ff-only`, **skipping any dirty clone** (never `reset`/`stash` — your work is safe). New `ALHAZEN_SKILL_SOURCES` var; new `stage-skills` target (wired into `build-skills` + `skills-update`).
- **docker-compose** — `typedb-init` and `gateway` read skills from the `.skills-build` mount; gateway `SKILL_ROOT` points at it. Pinned `typedb-init` driver to `3.8.0` (latest `3.11.5` can't handshake the 3.8 server).
- **gateway/Dockerfile + dispatcher.py** — stop baking skill code; `SKILL_ROOT`-configurable skill root. **dashboard/Dockerfile** — COPY the staged tree instead of the now-symlinked `local_skills`.
- **check_skills_upstream.py** — rewritten **git-native**: fails on uncommitted/unpushed work in a clone, treats merely-behind as safe (distinguishes a real edit from stale — the temp-clone version couldn't).
- **compile_schema_map.py** — emit stable `local_skills/<name>` schema paths, never the resolved absolute clone path.

## Verification (live)

- `make skills-install` → external skills are symlinks into `~/Documents/GitHub/<repo>/<subdir>`; examples repo cloned once; `make build-skills` chain (install → deploy → stage 14 → schema-map) green.
- `make skills-check` (git-native): examples & mythras clean & in sync, dismech "behind — safe to update" (non-failing). Uncommitted/unpushed in a clone → fails; `FORCE=1` bypasses; dirty clone never stomped.
- `docker compose up`: **typedb-init exits 0** loading schemas from the `/skills` mount (also fixes the long-standing `ModuleNotFoundError` + driver-mismatch); **gateway** healthy, `/health` lists 14 skills **from the mount**, `/run scientific-literature list-collections` → 3 corpora; **dashboard** 200.
- `pytest tests/test_gateway.py` 5/5; `ruff` clean.

## Migration note

The detached `local_skills/` dirs were verified to match upstream before re-linking (no unique edits lost). The 3 source clones already existed at `~/Documents/GitHub`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)