### PR TITLE
perf(deps): remove the torch/CUDA stack — gateway 8.3GB→714MB, dashboard 11.8→4.4GB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ build-dashboard: build-skills ## Wire skill dashboard pages/routes/components in
 	for f in dashboard/src/lib/*.ts; do \
 	  [ -f "$$f" ] || [ -L "$$f" ] || continue; \
 	  skill_name=$$(basename "$$f" .ts); \
-	  [ "$$skill_name" = "utils" ] && continue; \
+	  case "$$skill_name" in utils|skill-gateway) continue;; esac; \
 	  echo " $$PUBLIC_SKILLS " | grep -q " $$skill_name " || { \
 	    echo "  Removing stale lib file: $$f"; rm -f "$$f"; }; \
 	done; \

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -22,12 +22,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends build-essential
 COPY pyproject.toml uv.lock README.md ./
 # Copy source for version detection (pyproject.toml uses dynamic version from __init__.py)
 COPY src/skillful_alhazen/__init__.py ./src/skillful_alhazen/
-# semantic = umap-learn + hdbscan + numpy (scilit map/cluster).
+# semantic = umap-learn + hdbscan + numpy (scilit map/cluster). No torch: the
+# only torch user (jobhunt's embedding map, via pymde) is not a registered skill.
 RUN uv sync --extra typedb --extra skills --extra skilllog --extra qdrant --extra semantic --no-dev
-# pymde + torch (jobhunt embedding map) are installed via a FRESH resolve so
-# --torch-backend=cpu selects CPU wheels — `uv sync` would install the locked
-# CUDA build (~2.8GB of NVIDIA wheels). No GPU exists in this container.
-RUN uv pip install --python /app/.venv/bin/python --torch-backend=cpu pymde
 
 # ==============================================================================
 # Stage 2b: Generate skills-config.json from skills-registry.yaml

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -22,9 +22,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends build-essential
 COPY pyproject.toml uv.lock README.md ./
 # Copy source for version detection (pyproject.toml uses dynamic version from __init__.py)
 COPY src/skillful_alhazen/__init__.py ./src/skillful_alhazen/
-# semantic = umap-learn + hdbscan + numpy — required by the `map`/`cluster`
-# commands the dashboard's embedding-map view calls.
+# semantic = umap-learn + hdbscan + numpy (scilit map/cluster).
 RUN uv sync --extra typedb --extra skills --extra skilllog --extra qdrant --extra semantic --no-dev
+# pymde + torch (jobhunt embedding map) are installed via a FRESH resolve so
+# --torch-backend=cpu selects CPU wheels — `uv sync` would install the locked
+# CUDA build (~2.8GB of NVIDIA wheels). No GPU exists in this container.
+RUN uv pip install --python /app/.venv/bin/python --torch-backend=cpu pymde
 
 # ==============================================================================
 # Stage 2b: Generate skills-config.json from skills-registry.yaml

--- a/dashboard/public/namespace-config.json
+++ b/dashboard/public/namespace-config.json
@@ -12,6 +12,11 @@
     "badge": "OS",
     "color": "rust"
   },
+  "aos": {
+    "badge": "SKILL",
+    "color": "blue",
+    "skill": "agent-os"
+  },
   "coach": {
     "badge": "SKILL",
     "color": "blue",
@@ -22,10 +27,10 @@
     "color": "blue",
     "skill": "curation-skill-builder"
   },
-  "jhunt": {
+  "myth": {
     "badge": "SKILL",
     "color": "blue",
-    "skill": "jobhunt"
+    "skill": "mythras-gm"
   },
   "scilit": {
     "badge": "SKILL",

--- a/dashboard/public/skills-config.json
+++ b/dashboard/public/skills-config.json
@@ -18,15 +18,6 @@
     "color": "cyan"
   },
   {
-    "slug": "jobhunt",
-    "enabled": true,
-    "name": "Jobhunt",
-    "description": "Track job applications, analyze skill gaps, and manage your career search.",
-    "url_path": "/jobhunt",
-    "icon": "Briefcase",
-    "color": "indigo"
-  },
-  {
     "slug": "tech-recon",
     "enabled": true,
     "name": "Tech Recon",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "sf-hamilton>=1.75.0",
     "anthropic>=0.97.0",
     "matplotlib>=3.10.8",
-    "pymde>=0.3.0",
 ]
 
 [project.optional-dependencies]
@@ -84,8 +83,15 @@ semantic = [
 pipeline = [
     "sf-hamilton>=1.75.0",
 ]
+# PyMDE pulls torch (+ ~2.8GB of NVIDIA CUDA wheels on Linux). Only jobhunt's
+# embedding_map.py uses it, so it is opt-in — containers that don't need it
+# (e.g. the gateway) skip the entire torch stack. Install CPU torch with
+# UV_TORCH_BACKEND=cpu to avoid the CUDA wheels.
+embedding-map = [
+    "pymde>=0.3.0",
+]
 all = [
-    "skillful-alhazen[typedb,dev,skills,skilllog,semantic,pipeline,gateway]",
+    "skillful-alhazen[typedb,dev,skills,skilllog,semantic,pipeline,gateway,embedding-map]",
 ]
 
 [project.scripts]

--- a/skills-registry.yaml
+++ b/skills-registry.yaml
@@ -39,16 +39,6 @@ skills:
     url_path: /scientific-literature
     icon: BookOpen
     color: cyan
-- name: jobhunt
-  subdir: skills/demo/jobhunt
-  dashboard:
-    enabled: true
-    name: Jobhunt
-    description: Track job applications, analyze skill gaps, and manage your career
-      search.
-    url_path: /jobhunt
-    icon: Briefcase
-    color: indigo
 - name: tech-recon
   path: skills/tech-recon
   dashboard:
@@ -93,7 +83,6 @@ schema_map:
   - coach
   - curation-skill-builder
   - dismech-notebook
-  - jobhunt
   - mythras-gm
   - scientific-literature
   - tech-recon
@@ -113,10 +102,6 @@ schema_map:
     dm:
       skill: curation-skill-builder
       schema: local_skills/curation-skill-builder/schema.tql
-      depends_on: []
-    jhunt:
-      skill: jobhunt
-      schema: local_skills/jobhunt/schema.tql
       depends_on: []
     myth:
       skill: mythras-gm

--- a/uv.lock
+++ b/uv.lock
@@ -3463,7 +3463,6 @@ dependencies = [
     { name = "matplotlib" },
     { name = "pdfplumber" },
     { name = "pydantic" },
-    { name = "pymde" },
     { name = "python-docx" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -3478,6 +3477,7 @@ all = [
     { name = "hdbscan" },
     { name = "matplotlib" },
     { name = "numpy" },
+    { name = "pymde" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -3497,6 +3497,9 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+]
+embedding-map = [
+    { name = "pymde" },
 ]
 gateway = [
     { name = "fastapi" },
@@ -3555,7 +3558,8 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'semantic'", specifier = ">=1.26.0" },
     { name = "pdfplumber", specifier = ">=0.11.0" },
     { name = "pydantic", specifier = ">=2.5.0" },
-    { name = "pymde", specifier = ">=0.3.0" },
+    { name = "pymde", marker = "extra == 'all'", specifier = ">=0.3.0" },
+    { name = "pymde", marker = "extra == 'embedding-map'", specifier = ">=0.3.0" },
     { name = "pytest", marker = "extra == 'all'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'all'" },
@@ -3592,7 +3596,7 @@ requires-dist = [
     { name = "voyageai", marker = "extra == 'semantic'", specifier = ">=0.3.0" },
     { name = "youtube-transcript-api", marker = "extra == 'they-said-whaaa'", specifier = ">=0.6" },
 ]
-provides-extras = ["all", "dev", "gateway", "mcp", "pipeline", "qdrant", "semantic", "skilllog", "skills", "they-said-whaaa", "typedb"]
+provides-extras = ["all", "dev", "embedding-map", "gateway", "mcp", "pipeline", "qdrant", "semantic", "skilllog", "skills", "they-said-whaaa", "typedb"]
 
 [[package]]
 name = "sniffio"


### PR DESCRIPTION
## Problem

The container images carried **~4.5 GB of GPU libraries** (NVIDIA CUDA 2.8 GB + torch 864 MB + triton 599 MB) that nothing in the running system uses. Root cause: `pymde` was a base `dependency`, so every `uv sync` pulled torch. The *only* torch user across all skills is `jobhunt/embedding_map.py`.

## Fix

- **pyproject**: move `pymde` out of base `dependencies` into an opt-in `embedding-map` extra. The gateway (`typedb/skills/qdrant/gateway`) now pulls **no torch**.
- **Remove `jobhunt` from the registry** (its embedding map will be refactored off torch → umap later). It was the sole torch consumer, so the **dashboard now needs no torch at all** — dropped the pymde install from `dashboard/Dockerfile`.
- **Makefile**: `build-dashboard` now preserves the hand-maintained `dashboard/src/lib/skill-gateway.ts` (like `utils.ts`) instead of pruning it as a stale skill lib.
- Regenerated `skills-config.json` / `namespace-config.json` (jobhunt/jhunt removed).

## Results (rebuilt + verified)

| Image | Before | After |
|---|--:|--:|
| **gateway** | 8.3 GB | **714 MB** |
| **dashboard** | 11.8 GB | **4.4 GB** |

No `torch`/`pymde`/`nvidia`/`triton` in either image. Verified: gateway `/health` lists **13 skills** (no jobhunt), serving from the mount; scilit map → 60 points (semantic/umap untouched); `make skills-check` green.

> Stacked on #55 (`feat/skills-mounted-sources`). Merge after #55.
> jobhunt is removed *temporarily* — re-add it (with a torch-free embedding map) by restoring its `skills-registry.yaml` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)