### PR TITLE
fix(skills): stage-skills clears .skills-build in place (don't break live mounts)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -883,7 +883,10 @@ skills-install: ## Resolve skills-registry.yaml into local_skills/ (path: symlin
 .PHONY: stage-skills
 stage-skills: ## Materialize a symlink-free skill tree into ./.skills-build for container mounts
 	@echo "$(BLUE)Staging skills into .skills-build/ ...$(NC)"
-	@rm -rf "$(STAGED_SKILLS_DIR)" && mkdir -p "$(STAGED_SKILLS_DIR)"
+	@# Clear contents in place (keep the directory inode) so a running container's
+	@# bind mount of ./.skills-build is not invalidated by re-staging.
+	@mkdir -p "$(STAGED_SKILLS_DIR)"
+	@find "$(STAGED_SKILLS_DIR)" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
 	@for skill_dir in $(LOCAL_SKILLS_DIR)/*/; do \
 		[ -e "$$skill_dir" ] || continue; \
 		name=$$(basename "$$skill_dir"); \


### PR DESCRIPTION
## Problem

`make stage-skills` did `rm -rf .skills-build && mkdir` — replacing the directory inode. The gateway and typedb-init bind-mount `./.skills-build`, so any re-stage (which `build-skills`/`build-dashboard` trigger) left the running container's mount pointing at the deleted inode → **gateway reported 0 skills** until restarted. This defeats the keep-warm model (re-stage should be live).

## Fix

Clear the directory's *contents* in place (`find .skills-build -mindepth 1 -maxdepth 1 -exec rm -rf {} +`) instead of removing the directory — preserving the inode so live bind mounts stay valid.

## Verified

inode preserved across `make stage-skills`; the running gateway reflects the re-staged tree (13 skills) **with no restart**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)