### PR TITLE
feat(dashboard): route in-repo skill libs through the warm gateway

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -22,9 +22,10 @@ WORKDIR /app
 COPY pyproject.toml uv.lock README.md ./
 # Source needed for the dynamic version (pyproject reads src/.../__init__.py)
 COPY src/skillful_alhazen/__init__.py ./src/skillful_alhazen/
-# Mirror the dashboard's proven extra set (skills' heavy semantic deps are
-# imported lazily inside commands) plus the gateway's own deps.
-RUN uv sync --extra typedb --extra skills --extra skilllog --extra qdrant --extra gateway --no-dev
+# Skill runtime deps + the gateway's own. pipeline (sf-hamilton) is needed at
+# import time by tech_recon.py. semantic (umap/hdbscan/voyage) is added when
+# scilit's lib migrates to the gateway.
+RUN uv sync --extra typedb --extra skills --extra skilllog --extra qdrant --extra pipeline --extra gateway --no-dev
 
 # ==============================================================================
 # Stage 3: Runtime

--- a/skills/agentic-memory/dashboard/lib.ts
+++ b/skills/agentic-memory/dashboard/lib.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import path from 'path';
+import { runSkill, gatewayConfigured } from '@/lib/skill-gateway';
 
 const execFileAsync = promisify(execFile);
 
@@ -11,7 +12,10 @@ const AGENTIC_MEMORY_SCRIPT = path.join(
   '.claude/skills/agentic-memory/agentic_memory.py'
 );
 
+// Prefer the warm gateway (no per-request Python cold-start); fall back to
+// spawning the CLI directly for host dev where no gateway is running.
 async function runAgenticMemory(args: string[]): Promise<unknown> {
+  if (gatewayConfigured()) return runSkill('agentic-memory', args);
   const { stdout } = await execFileAsync(
     'uv',
     ['run', 'python', AGENTIC_MEMORY_SCRIPT, ...args],

--- a/skills/curation-skill-builder/dashboard/lib.ts
+++ b/skills/curation-skill-builder/dashboard/lib.ts
@@ -1,13 +1,17 @@
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import path from 'path';
+import { runSkill, gatewayConfigured } from '@/lib/skill-gateway';
 
 const execFileAsync = promisify(execFile);
 
 const PROJECT_ROOT = process.env.PROJECT_ROOT || path.resolve(process.cwd());
 const SCRIPT = path.join(PROJECT_ROOT, '.claude/skills/curation-skill-builder/skill_builder.py');
 
+// Prefer the warm gateway (no per-request Python cold-start); fall back to
+// spawning the CLI directly for host dev where no gateway is running.
 async function runDomainModeling(args: string[]): Promise<unknown> {
+  if (gatewayConfigured()) return runSkill('curation-skill-builder', args);
   const { stdout } = await execFileAsync(
     'uv',
     ['run', 'python', SCRIPT, ...args],

--- a/skills/tech-recon/dashboard/lib.ts
+++ b/skills/tech-recon/dashboard/lib.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import path from 'path';
+import { runSkill, gatewayConfigured } from '@/lib/skill-gateway';
 
 const execFileAsync = promisify(execFile);
 
@@ -15,7 +16,10 @@ const TECH_RECON_SCRIPT = SKILL_ROOT
 
 const CWD = SKILL_ROOT || PROJECT_ROOT;
 
+// Prefer the warm gateway (no per-request Python cold-start); fall back to
+// spawning the CLI directly for host dev where no gateway is running.
 async function runTechRecon(args: string[]): Promise<unknown> {
+  if (gatewayConfigured()) return runSkill('tech-recon', args);
   const { stdout } = await execFileAsync(
     'uv',
     ['run', 'python', TECH_RECON_SCRIPT, ...args],

--- a/src/skillful_alhazen/gateway/dispatcher.py
+++ b/src/skillful_alhazen/gateway/dispatcher.py
@@ -59,7 +59,8 @@ def _skill_root(skill: str) -> Path:
 def _primary_entrypoint(skill: str, root: Path) -> str:
     """Determine a skill's default script stem from its skill.yaml.
 
-    Handles both ``cli: agentic_memory.py`` and ``scripts: [jobhunt.py, ...]``.
+    Skills declare the entrypoint three different ways: ``cli: agentic_memory.py``,
+    ``script: skill_builder.py`` (singular), or ``scripts: [jobhunt.py, ...]``.
     Falls back to the skill name with dashes converted to underscores.
     """
     manifest = root / "skill.yaml"
@@ -67,6 +68,8 @@ def _primary_entrypoint(skill: str, root: Path) -> str:
         data = yaml.safe_load(manifest.read_text(encoding="utf-8")) or {}
         if data.get("cli"):
             return Path(data["cli"]).stem
+        if data.get("script"):
+            return Path(data["script"]).stem
         scripts = data.get("scripts")
         if isinstance(scripts, list) and scripts:
             return Path(scripts[0]).stem


### PR DESCRIPTION
## What

First step of moving the dashboard off per-request `uv run python <skill>.py`. The in-repo skill libs now call the **warm gateway** (`runSkill()`), eliminating Python cold-start for those pages.

- **agentic-memory, tech-recon, curation-skill-builder** `dashboard/lib.ts`: each `runX()` helper calls `runSkill('<skill>', args)` when `SKILL_GATEWAY_URL` is set, and **falls back to `execFile`** for host dev (no gateway running).
- **gateway/Dockerfile**: `+ --extra pipeline` — `tech_recon.py` imports `hamilton` at module load, so the gateway needs sf-hamilton to dispatch tech-recon. (sf-hamilton is tiny; gateway stays 714 MB.)
- **dispatcher**: also honor `script:` (singular) in `skill.yaml`. Skills declare the entrypoint three ways — `cli:` (agentic-memory), `script:` (curation-skill-builder), `scripts:` (was jobhunt). All three now resolve.

## Verified

- Gateway `/run` runs all three: `agentic-memory list-persons` (ok, exit 0), `tech-recon list-investigations` (ok, exit 0 — proves the hamilton dep), `curation-skill-builder list-domains` (resolves to `skill_builder.py`).
- Live dashboard pages 200: `/agentic-memory`, `/tech-recon`, `/scientific-literature`.

## Follow-ups

- External skills (scientific-literature, coach, dismech-notebook) live in upstream clones — their lib migration goes upstream. When scilit's lib moves over, the gateway gains `--extra semantic` (umap/hdbscan) so its map/cluster commands run there.
- Once **all** libs are migrated, the dashboard image can drop Python entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)