### PR TITLE
feat(gateway): semantic extra — completes dashboard→gateway migration

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -19,13 +19,17 @@ ENV PATH="/root/.local/bin:$PATH"
 # ==============================================================================
 FROM python-base AS deps
 WORKDIR /app
+# build-essential lets the semantic extra's compiled deps (hdbscan) build from
+# source. This stage is discarded — the runtime image only copies /app/.venv.
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
 COPY pyproject.toml uv.lock README.md ./
 # Source needed for the dynamic version (pyproject reads src/.../__init__.py)
 COPY src/skillful_alhazen/__init__.py ./src/skillful_alhazen/
-# Skill runtime deps + the gateway's own. pipeline (sf-hamilton) is needed at
-# import time by tech_recon.py. semantic (umap/hdbscan/voyage) is added when
-# scilit's lib migrates to the gateway.
-RUN uv sync --extra typedb --extra skills --extra skilllog --extra qdrant --extra pipeline --extra gateway --no-dev
+# Skill runtime deps + the gateway's own. pipeline (sf-hamilton) for tech_recon.py;
+# semantic (umap/hdbscan/voyage) for scilit map/cluster/embed. No torch — pymde
+# stays in the embedding-map extra.
+RUN uv sync --extra typedb --extra skills --extra skilllog --extra qdrant --extra pipeline --extra semantic --extra gateway --no-dev
 
 # ==============================================================================
 # Stage 3: Runtime


### PR DESCRIPTION
## What

Completes routing the dashboard data layer through the warm gateway. The scientific-literature lib was migrated to the gateway (upstream), so the gateway must run scilit's semantic commands (`map`/`cluster`/`embed` → umap + hdbscan + voyage). This PR adds `--extra semantic` (+ `build-essential` for hdbscan) to `gateway/Dockerfile`. **No torch** (pymde stays in `embedding-map`). Gateway **714 MB → 1.28 GB**.

## The migration (this completes it)

All five wired dashboards now call the gateway (`runSkill()`, with an `execFile` fallback for host dev):
- **In-repo** (merged #59): agentic-memory, tech-recon, curation-skill-builder.
- **Upstream** (pushed this session): scientific-literature + coach → `alhazen-skill-examples`; dismech-notebook → `alhazen-skill-dismech`.

## Verified

- Gateway `/run`: scilit `list-collections`, coach `latest`, dismech `stats` all ok; **scilit `map` → 60 points** (umap/hdbscan on the gateway).
- Dashboard `/api/scientific-literature/map` routes through the gateway → 60 points.
- `make skills-check` green (clones clean & pushed).

## Follow-up

With every dashboard lib on the gateway, the **dashboard image can now drop Python entirely** (it only kept it for the execFile fallback, which the container never uses since `SKILL_GATEWAY_URL` is always set). That's the next PR — dashboard 4.4 GB → ~Node-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)