### PR TITLE
perf(dashboard): serve the Next.js standalone build (3.14GB→450MB)

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -74,15 +74,18 @@ WORKDIR /app/dashboard
 RUN npm run build
 
 # ==============================================================================
-# Stage 3: Final runtime (Node only — no Python)
+# Stage 3: Final runtime (Node only — Next.js standalone server)
 # ==============================================================================
 FROM node:20-slim AS runner
 WORKDIR /app
 
-COPY --from=node-builder /app/dashboard/.next ./.next
+# next.config has output: 'standalone' — ship the traced minimal server + its
+# ~88MB node_modules instead of the full 1.5GB build node_modules (which carries
+# Electron/electron-builder + build tooling the server never runs). standalone
+# does NOT include public/ or .next/static — copy those two explicitly.
+COPY --from=node-builder /app/dashboard/.next/standalone ./
+COPY --from=node-builder /app/dashboard/.next/static ./.next/static
 COPY --from=node-builder /app/dashboard/public ./public
-COPY --from=node-builder /app/dashboard/package*.json ./
-COPY --from=node-builder /app/dashboard/node_modules ./node_modules
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
@@ -90,4 +93,4 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
-CMD ["npm", "start"]
+CMD ["node", "server.js"]


### PR DESCRIPTION
## What

`next.config.ts` already sets `output: 'standalone'`, but the Dockerfile ignored it — shipping the full **1.5 GB** build `node_modules` and running `npm start`. That node_modules is mostly tooling the server never runs: **Electron 261 MB + electron-builder/app-builder-bin 207 MB**, plus Next's build half and TypeScript.

Point the runner at the standalone bundle: a file-traced `server.js` + an **88 MB** node_modules. Per the standalone contract, `.next/static` and `public/` are copied separately (standalone omits them), and we run `node server.js`.

## Results

| | Before | After |
|---|--:|--:|
| dashboard image | 3.14 GB | **450 MB** |

Verified: all five pages 200; a `/_next/static/*.css` asset returns 200 (static + public wired correctly — the classic standalone gotcha); `corpora` (3) + scilit `map` (60) served through the gateway.

## The dashboard image, full arc

`11.8 GB` (Node+Python monolith) → `4.4 GB` (drop torch/CUDA) → `3.14 GB` (drop Python) → **`450 MB`** (standalone). All skill execution now lives in the gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)