### PR TITLE
Dual-mode: publishable plugin marketplace + registry-only local dev

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,101 @@
+{
+  "name": "skillful-alhazen",
+  "owner": {
+    "name": "Gully Burns"
+  },
+  "metadata": {
+    "description": "Core skills for Skillful Alhazen — TypeDB-powered agentic knowledge notebook",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "alhazen-core",
+      "source": "./skills/alhazen-core",
+      "description": "TypeDB infrastructure -- auto-starts via Docker, creates database, loads base schema. Install this first before any other Alhazen skill.",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "keywords": [
+        "typedb",
+        "infrastructure",
+        "setup"
+      ]
+    },
+    {
+      "name": "agentic-memory",
+      "source": "./skills/agentic-memory",
+      "description": "TypeDB-backed knowledge graph memory — schema browser, entity explorer, session episodes, memory claims",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "keywords": [
+        "typedb",
+        "knowledge-graph",
+        "memory",
+        "agentic"
+      ]
+    },
+    {
+      "name": "typedb-notebook",
+      "source": "./skills/typedb-notebook",
+      "description": "Store and retrieve knowledge in the Alhazen TypeDB knowledge graph — remember, recall, organize notes and collections",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "keywords": [
+        "typedb",
+        "knowledge-graph",
+        "memory",
+        "notes"
+      ]
+    },
+    {
+      "name": "web-search",
+      "source": "./skills/web-search",
+      "description": "Search the web using SearXNG (self-hosted metasearch — no API key needed)",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "keywords": [
+        "search",
+        "web",
+        "searxng"
+      ]
+    },
+    {
+      "name": "curation-skill-builder",
+      "source": "./skills/curation-skill-builder",
+      "description": "Design and implement TypeDB-backed curation skills using the Skillful Alhazen 6-phase methodology",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "keywords": [
+        "typedb",
+        "skill-design",
+        "curation",
+        "meta-skill"
+      ]
+    },
+    {
+      "name": "tech-recon",
+      "source": "./skills/tech-recon",
+      "description": "Goal-driven technology investigation — interview, discover, ingest, analyze, and visualize competing systems against user-defined success criteria",
+      "version": "0.1.0",
+      "license": "MIT",
+      "keywords": [
+        "research",
+        "technology",
+        "visualization",
+        "investigation"
+      ]
+    },
+    {
+      "name": "agent-os",
+      "source": "./skills/agent-os",
+      "description": "Large-scale operator context dataset -- ingests Gmail, Calendar, GitHub, LinkedIn, Drive, and HealthKit into TypeDB for rich structured personal context.",
+      "version": "0.1.0",
+      "license": "MIT",
+      "keywords": [
+        "typedb",
+        "context",
+        "operator",
+        "agentic"
+      ]
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,13 +103,17 @@ Read these **before** the relevant task — they are NOT auto-loaded:
 | [`docs/troubleshooting-sessionstart-hooks.md`](docs/troubleshooting-sessionstart-hooks.md) | `SessionStart:clear hook Failed` errors, typedb-driver segfaults on Python 3.14 |
 | `local_resources/typedb/llms.txt` | Full TypeDB 3.x query reference (load on demand) |
 
-## Skill Loading: Registry-Only (no local plugin tooling)
+## Skill Loading: Dual-Mode (publishable marketplace + registry-only local dev)
 
-**Every skill loads through ONE path: the registry.** `skills-registry.yaml` (committed) + `skills-registry-local.yaml` (gitignored local overrides) → `make build-skills` → `local_skills/<name>` symlinks → `.claude/skills/<name>`. Skills load with **bare names** (`tech-recon`, `jobhunt`). External skills point at upstream clones via `subdir:` (default git) or absolute `path:`.
+This repo has **two non-overlapping loading paths**. They never mix — that separation is the whole design.
 
-**This repo is NOT a Claude Code plugin marketplace.** There is no `.claude-plugin/marketplace.json`, no `validate_plugins.py`, and the repo must NOT be registered in `~/.claude/settings.json` `extraKnownMarketplaces`. The plugin/marketplace architecture (per-skill `plugin.json` + `hooks/`, marketplace manifest) lives in each skill's **upstream repo** — when you change a skill, reproduce the fix upstream and publish it there. Do not enable alhazen skills as plugins locally; the plugin cache pins to an old commit and will shadow the live registry copy with stale code (this is what broke `jobhunt` against the migrated `jhunt-*` data).
+**1. LOCAL DEV (how you, the maintainer, work) — registry-only.** Every skill loads through ONE path: the registry. `skills-registry.yaml` (committed) + `skills-registry-local.yaml` (gitignored local overrides) → `make build-skills` → `local_skills/<name>` symlinks → `.claude/skills/<name>`. Skills load with **bare names** (`tech-recon`, `jobhunt`). External skills point at upstream clones via `subdir:` (default git) or absolute `path:`. **TypeDB autostart** is delivered at the project level: `make deploy-claude-settings` writes a `SessionStart` hook into `.claude/settings.json` that runs `local_skills/alhazen-core/alhazen_core.py init` — it does NOT depend on any plugin being installed.
 
-**TypeDB autostart** is delivered at the project level: `make deploy-claude-settings` writes a `SessionStart` hook into `.claude/settings.json` that runs `local_skills/alhazen-core/alhazen_core.py init`. It does NOT depend on any plugin being installed.
+**2. EXTERNAL USERS — this repo IS a publishable Claude Code marketplace.** `.claude-plugin/marketplace.json` (repo root) publishes the **7 in-repo core skills** (`alhazen-core`, `agentic-memory`, `typedb-notebook`, `web-search`, `curation-skill-builder`, `tech-recon`, `agent-os`). External users run `/plugin marketplace add sciknow-io/skillful-alhazen` → `/plugin install <skill>@skillful-alhazen`. On that path TypeDB autostart comes from `alhazen-core`'s OWN `hooks/hooks.json` SessionStart hook (`${CLAUDE_PLUGIN_ROOT}/alhazen_core.py init`). Keep the manifest correct with `make validate-plugins` (`scripts/validate_plugins.py`). External (non-core) skills — `scientific-literature`, `jobhunt`, `dismech-notebook`, etc. — self-publish from their own upstream marketplaces; this manifest is core-only.
+
+**NEVER let the local clone act like a marketplace.** Do NOT `/plugin marketplace add` this repo locally, and do NOT enable any alhazen skill as a plugin in `~/.claude/settings.json` / project `.claude/settings.json`. The plugin cache pins an old commit and **shadows the live registry copy with stale code** (this is what broke `jobhunt` against the migrated `jhunt-*` data). The active guard `scripts/check_no_local_marketplace.py` (run automatically by `make build-skills`) warns loudly if it ever detects this repo in `extraKnownMarketplaces` or a core skill in `enabledPlugins`. The marketplace manifest is *inert* — it does nothing until someone explicitly registers it — so it sits in the repo harmlessly while you develop via the registry.
+
+> When you change an external skill, still reproduce the fix in its **upstream repo** and publish there; `make skills-update` pulls it back. Only the 7 core skills live-and-publish from THIS repo.
 
 ## Parallel Work-Thread Worktrees
 

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ build-env: ## Install Python dependencies
 build-skills: skills-install deploy-claude stage-skills ## Resolve skills-registry.yaml → local_skills/ + wire .claude/skills/ + stage for containers
 	@echo "$(BLUE)Compiling schema map...$(NC)"
 	@uv run python scripts/compile_schema_map.py --registry $(SKILLS_REGISTRY)
+	@python3 scripts/check_no_local_marketplace.py || true
 	@echo "$(GREEN)✓ Skills built$(NC)"
 
 .PHONY: build-agents
@@ -425,7 +426,7 @@ endif
 
 .PHONY: deploy-claude-settings
 deploy-claude-settings: ## Write .claude/settings.json with portable PostToolUse hook
-	@printf '{\n  "hooks": {\n    "PostToolUse": [\n      {\n        "matcher": "Bash",\n        "hooks": [\n          {\n            "type": "command",\n            "command": "REPO=$$(git rev-parse --show-toplevel 2>/dev/null) && [ -f \\"$$REPO/local_resources/skilllog/skill_logger.py\\" ] && cd \\"$$REPO\\" && uv run python \\"$$REPO/local_resources/skilllog/skill_logger.py\\""\n          }\n        ]\n      }\n    ]\n  }\n}\n' > $(PROJECT_ROOT)/.claude/settings.json
+	@printf '{\n  "hooks": {\n    "SessionStart": [\n      {\n        "hooks": [\n          {\n            "type": "command",\n            "command": "REPO=$$(git rev-parse --show-toplevel 2>/dev/null) && CORE=\\"$$REPO/local_skills/alhazen-core/alhazen_core.py\\" && [ -f \\"$$CORE\\" ] && cd \\"$$REPO\\" && unset VIRTUAL_ENV && uv run --project \\"$$REPO/local_skills/alhazen-core\\" python \\"$$CORE\\" init",\n            "timeout": 90000\n          }\n        ]\n      }\n    ],\n    "PostToolUse": [\n      {\n        "matcher": "Bash",\n        "hooks": [\n          {\n            "type": "command",\n            "command": "REPO=$$(git rev-parse --show-toplevel 2>/dev/null) && [ -f \\"$$REPO/local_resources/skilllog/skill_logger.py\\" ] && cd \\"$$REPO\\" && uv run python \\"$$REPO/local_resources/skilllog/skill_logger.py\\""\n          }\n        ]\n      }\n    ]\n  }\n}\n' > $(PROJECT_ROOT)/.claude/settings.json
 	@echo "$(GREEN)  ✓ Wrote .claude/settings.json$(NC)"
 
 .PHONY: deploy-claude
@@ -999,8 +1000,8 @@ lint: ## Run ruff linter
 	@echo "$(GREEN)✓ Linting completed$(NC)"
 
 .PHONY: validate-plugins
-validate-plugins: ## Check every marketplace plugin against the plugin-architecture bar
-	@echo "$(BLUE)Validating plugins...$(NC)"
+validate-plugins: ## Validate the published marketplace (.claude-plugin/marketplace.json)
+	@echo "$(BLUE)Validating marketplace plugins...$(NC)"
 	python3 scripts/validate_plugins.py
 	@echo "$(GREEN)✓ Plugins valid$(NC)"
 

--- a/scripts/check_no_local_marketplace.py
+++ b/scripts/check_no_local_marketplace.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Guard: this clone must stay registry-only — it must NEVER act like a marketplace.
+
+skillful-alhazen ships a publishable plugin marketplace (`.claude-plugin/marketplace.json`)
+for EXTERNAL users. Locally, skills load via the registry (`make build-skills` ->
+`.claude/skills/<name>` symlinks). The two paths must never mix: if the maintainer registers
+THIS repo as a marketplace and installs an alhazen skill as a plugin, the plugin cache pins an
+old commit and SHADOWS the live registry copy with stale code (this is what broke `jobhunt`
+against the migrated `jhunt-*` data).
+
+This check reads `~/.claude/settings.json` and the project `.claude/settings.json` and WARNS
+(loudly, but never fails — exit 0 always) when it finds the dangerous overlap:
+  * this repo registered in `extraKnownMarketplaces`, or
+  * any core skill enabled as a plugin (`<skill>@skillful-alhazen` or a bare core-skill key)
+    in `enabledPlugins`.
+
+Run: `python scripts/check_no_local_marketplace.py`  (also called from `make build-skills`).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+MARKETPLACE_NAME = "skillful-alhazen"
+REPO_SLUG = "sciknow-io/skillful-alhazen"
+ROOT = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+
+# The 7 in-repo core skills published by this marketplace.
+CORE_SKILLS = {
+    "alhazen-core", "agentic-memory", "typedb-notebook", "web-search",
+    "curation-skill-builder", "tech-recon", "agent-os",
+}
+
+YELLOW, RED, RESET = "\033[33m", "\033[31m", "\033[0m"
+
+
+def _load(path: str) -> dict:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh) or {}
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+
+def _marketplace_is_this_repo(entry: object) -> bool:
+    """True if an extraKnownMarketplaces entry points at THIS repo (github slug or local path)."""
+    src = entry.get("source", entry) if isinstance(entry, dict) else entry
+    if isinstance(src, dict):
+        repo = (src.get("repo") or "").lower()
+        if repo == REPO_SLUG.lower():
+            return True
+        path = src.get("path") or src.get("url") or ""
+        if path and os.path.realpath(os.path.expanduser(str(path))) == ROOT:
+            return True
+    elif isinstance(src, str):
+        if src.lower() == REPO_SLUG.lower():
+            return True
+        try:
+            if os.path.realpath(os.path.expanduser(src)) == ROOT:
+                return True
+        except OSError:
+            pass
+    return False
+
+
+def _scan(settings_path: str, label: str) -> list[str]:
+    data = _load(settings_path)
+    problems: list[str] = []
+
+    for name, entry in (data.get("extraKnownMarketplaces") or {}).items():
+        if name == MARKETPLACE_NAME or _marketplace_is_this_repo(entry):
+            problems.append(
+                f"[{label}] extraKnownMarketplaces['{name}'] registers THIS repo as a marketplace."
+            )
+
+    for key, enabled in (data.get("enabledPlugins") or {}).items():
+        if not enabled:
+            continue
+        plug = key.split("@", 1)[0]
+        market = key.split("@", 1)[1] if "@" in key else ""
+        if plug in CORE_SKILLS and (market == MARKETPLACE_NAME or market == ""):
+            problems.append(
+                f"[{label}] enabledPlugins['{key}'] enables a core skill as a plugin — it will "
+                f"SHADOW the live registry copy with stale cached code."
+            )
+    return problems
+
+
+def main() -> None:
+    home_settings = os.path.expanduser("~/.claude/settings.json")
+    proj_settings = os.path.join(ROOT, ".claude", "settings.json")
+    problems = _scan(home_settings, "~/.claude") + _scan(proj_settings, "project")
+
+    if not problems:
+        return  # silent on a clean (registry-only) environment
+
+    print(f"{RED}WARNING: local clone is configured to act like a marketplace.{RESET}",
+          file=sys.stderr)
+    for p in problems:
+        print(f"{YELLOW}  - {p}{RESET}", file=sys.stderr)
+    print(f"{YELLOW}  Local dev must stay registry-only. Remediate:{RESET}", file=sys.stderr)
+    print("      /plugin marketplace remove skillful-alhazen", file=sys.stderr)
+    print("      /plugin uninstall <skill>@skillful-alhazen", file=sys.stderr)
+    print(f"{YELLOW}  (Skills load via `make build-skills` -> .claude/skills, not via plugins.){RESET}",
+          file=sys.stderr)
+    # Warn only — never block legitimate work.
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Makes the repo instantiable as a Claude Code plugin marketplace from anywhere, **without** the maintainer's local clone behaving like one (it stays registry-only).

## The key fact
A `marketplace.json` is **inert** — it does nothing on clone; a marketplace only activates when someone explicitly runs `/plugin marketplace add` + `/plugin install`. So the published manifest and the local registry are two non-overlapping loading paths that coexist harmlessly.

## What's in here
- **Root `.claude-plugin/marketplace.json`** publishing the 7 in-repo core skills (`alhazen-core`, `agentic-memory`, `typedb-notebook`, `web-search`, `curation-skill-builder`, `tech-recon`, `agent-os`) with relative `./skills/<name>` sources. Discoverable via `/plugin marketplace add sciknow-io/skillful-alhazen` → `/plugin install <skill>@skillful-alhazen`. TypeDB autostart on the plugin path comes from `alhazen-core`'s own SessionStart hook (`${CLAUDE_PLUGIN_ROOT}`). External (non-core) skills self-publish from their own upstream marketplaces — this manifest is core-only.
- **Restored `scripts/validate_plugins.py` + `make validate-plugins`** — checks each plugin's source dir, `plugin.json`/version, `SKILL.md`, and the alhazen-core dependency/hook wiring. (→ `OK: 7 plugins valid`.)
- **`scripts/check_no_local_marketplace.py`** — warn-only guard, run automatically by `make build-skills`, that flags this repo in `extraKnownMarketplaces` or any core skill in `enabledPlugins` (the stale-plugin-cache shadowing that previously broke `jobhunt`). Silent on a clean environment.
- **CLAUDE.md** "Skill Loading" section rewritten from "NOT a marketplace" to the dual-mode model.

## Verification
- `make validate-plugins` → 7 plugins valid; manifest JSON valid; all 7 sources resolve; no root `plugin.json`.
- Guard detects all 3 problems in a fixture (marketplace + 2 core plugins) and is silent on the real env.
- Registry path unaffected — `.claude/skills/*` symlinks intact.
- **Manual step (not scriptable):** real external registration from a clean profile — `/plugin marketplace add sciknow-io/skillful-alhazen` then `/plugin install tech-recon@skillful-alhazen`. If relative sources are rejected, fall back to per-entry `github`+`path` sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)