### PR TITLE
feat(scilit): unified-investigation migration rules + KEfED/OOEVV design docs

### DIFF
--- a/docs/superpowers/plans/2026-06-29-scilit-schema-reconfiguration.md
+++ b/docs/superpowers/plans/2026-06-29-scilit-schema-reconfiguration.md
@@ -1,0 +1,829 @@
+# Scilit Schema Reconfiguration (Sub-project 1, Plan 1 of 3) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the muddled OOEVV/KEfED/KQED/investigation blocks of the scientific-literature
+`schema.tql` with the clean model from the design spec — OOEVV ElementSet as a first-class vocabulary,
+`kefed-model` as just the bigraph, template = uninstantiated model, typed data-transformations with
+parameter-mapping rules, span-anchored rhetorical claims, and first-class investigation iterations —
+validated by a scratch-DB round-trip harness.
+
+**Architecture:** TypeDB 3.8 schema (TypeQL). The reconfigured types live in the scilit namespace
+(`ooevv-*`, `kefed-*`, `scilit-*`) as subtypes of core `alh-*` bases. We validate each layer by loading
+the schema into a throwaway DB via `alhazen-core` and asserting a minimal insert/match round-trip — the
+existing pure-logic unit tests stay untouched; this plan adds the first DB-backed tests.
+
+**Tech Stack:** TypeDB 3.8.0, `typedb-driver>=3.8.0,<3.11`, Python 3.12, `uv`, pytest. Schema loaded via
+`alhazen-core`'s `alhazen_core.py {init,load-schema}`.
+
+## Global Constraints
+
+- **Upstream repo:** all edits are in `~/Documents/GitHub/alhazen-skill-deep-research/skills/scientific-literature/`
+  (the `local_skills/scientific-literature` symlink target). External-skill fixes go upstream; push there.
+- **TypeDB 3.x syntax (verbatim rules):** entity defs REQUIRE the `entity` keyword; relations declared
+  top-level as `relation X,` (never `sub relation`); attributes as `attribute X, value T;`; integers are
+  `value integer` (never `long`); no `@key` on custom attributes (only inherited `id @key`); declare
+  relations BEFORE the entities that `plays` their roles; subtypes must RE-declare `plays` (not inherited);
+  `@abstract` only on a subtype whose supertype is also abstract (`alh-domain-thing` is concrete);
+  ASCII-only in comments (no `->`, `°`, etc.).
+- **Never run a variable-free schema match** (`match X sub Y;` with two concrete labels) — it crashes the
+  server. Always bind a variable: `match $t sub ooevv-element;`.
+- **Back up before any reload of a real DB:** `make db-export` first. This plan only writes to a SCRATCH DB
+  (`alh_scilit_schema_test`), so live `alh_deep_research` is never touched — but the teardown plan (Plan 3)
+  will require the backup.
+- **CURIE grounding defaults (spec §6):** material-entity `obo:BFO_0000040`; ICE/variable `obo:IAO_0000030`;
+  process `obo:BFO_0000015`; assay `obo:OBI_0000070`; material-processing `obo:OBI_0000094`;
+  data-transformation `obo:OBI_0200000`; measurement `obo:IAO_0000109`; variable *definitions* ground to
+  **EFO** factor terms (via `kefed-efo-label`). Scales keep OOEVV's own taxonomy. Each element type carries
+  its upper-ontology CURIE via the existing `scilit-curie` slot; these are recorded as comments on the type
+  and (for instances) populated at curation time.
+
+---
+
+## File structure
+
+- `schema.tql` — the reconfigured OOEVV/KEfED/KQED/investigation blocks (current lines ~422-963 replaced).
+  Single file; one responsibility (the scilit schema). We replace the muddled blocks in place.
+- `tests/conftest.py` — **new**: a `scratch_db` pytest fixture that provisions a throwaway TypeDB database
+  with the core + scilit schema and yields a driver, dropping the DB on teardown.
+- `tests/test_schema_roundtrip.py` — **new**: one DB-backed round-trip test per schema layer, asserting the
+  new types insert and match. This is the executable spec of the reconfigured schema.
+
+The old types we retire (`kefed-slot`, `kefed-observed-via`, the ElementSet-fused `kefed-model` wiring,
+the prototype `kefed-model`/`kefed-variable` duplication, `scilit-claim`/`scilit-gap` legacy aliases) are
+removed from `schema.tql` as part of the layer tasks that supersede them; the DATA teardown is Plan 3.
+
+---
+
+## Task 1: Scratch-DB round-trip test harness
+
+**Files:**
+- Create: `tests/conftest.py`
+- Create: `tests/test_schema_roundtrip.py`
+
+**Interfaces:**
+- Produces: pytest fixture `scratch_db` → yields a `typedb` driver connected to a freshly-provisioned
+  `alh_scilit_schema_test` DB (core `alh-` schema + the current `schema.tql`), dropped on teardown.
+  Helpers `w(driver, q)` (write+commit) and `r(driver, q)` (read→list of rows), same signatures as `kqed.py`.
+
+- [ ] **Step 1: Write the fixture and helpers**
+
+Create `tests/conftest.py`:
+
+```python
+import os, subprocess, pytest
+from pathlib import Path
+from typedb.driver import TypeDB, Credentials, DriverOptions, TransactionType
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+SCRATCH_DB = "alh_scilit_schema_test"
+
+def _alhazen_core():
+    # Resolve alhazen-core's alhazen_core.py from the local registry build.
+    for c in [
+        SKILL_DIR.parent / "alhazen-core" / "alhazen_core.py",
+        Path.home() / "skillful-alhazen" / "local_skills" / "alhazen-core" / "alhazen_core.py",
+        Path.home() / "skillful-alhazen" / ".claude" / "skills" / "alhazen-core" / "alhazen_core.py",
+    ]:
+        if c.exists():
+            return c
+    raise RuntimeError("alhazen-core not found; build the registry (make build-skills) first")
+
+def _run_core(*args):
+    core = _alhazen_core()
+    env = {**os.environ, "TYPEDB_DATABASE": SCRATCH_DB, "PYTHONWARNINGS": "ignore::SyntaxWarning"}
+    env.pop("VIRTUAL_ENV", None)
+    subprocess.run(["uv", "run", "--project", str(core.parent), "python", str(core), *args],
+                   check=True, env=env, capture_output=True, text=True)
+
+def _driver():
+    return TypeDB.driver("localhost:1729", Credentials("admin", "password"),
+                         DriverOptions(is_tls_enabled=False))
+
+@pytest.fixture
+def scratch_db():
+    # Drop any stale scratch DB, then provision core + scilit schema fresh.
+    d = _driver()
+    if d.databases.contains(SCRATCH_DB):
+        d.databases.get(SCRATCH_DB).delete()
+    d.close()
+    _run_core("init")                                   # creates DB + core alh- schema
+    _run_core("load-schema", str(SKILL_DIR / "schema.tql"))
+    d = _driver()
+    try:
+        yield d
+    finally:
+        d.close()
+        d2 = _driver()
+        if d2.databases.contains(SCRATCH_DB):
+            d2.databases.get(SCRATCH_DB).delete()
+        d2.close()
+
+def w(driver, q):
+    with driver.transaction(SCRATCH_DB, TransactionType.WRITE) as tx:
+        tx.query(q).resolve(); tx.commit()
+
+def r(driver, q):
+    with driver.transaction(SCRATCH_DB, TransactionType.READ) as tx:
+        return list(tx.query(q).resolve())
+```
+
+- [ ] **Step 2: Write a smoke test that the harness provisions and the CURRENT schema loads**
+
+Create `tests/test_schema_roundtrip.py`:
+
+```python
+from conftest import w, r
+
+def test_harness_loads_current_schema(scratch_db):
+    # scilit-paper already exists in the current schema; a round-trip proves the harness works.
+    w(scratch_db, 'insert $p isa scilit-paper, has id "scilit-paper-smoke", has name "smoke";')
+    rows = r(scratch_db, 'match $p isa scilit-paper, has id "scilit-paper-smoke", has name $n; fetch {"n": $n};')
+    assert rows and rows[0]["n"] == "smoke"
+```
+
+- [ ] **Step 3: Run it to verify the harness works against today's schema**
+
+Run: `cd ~/Documents/GitHub/alhazen-skill-deep-research/skills/scientific-literature && uv run --python 3.12 pytest tests/test_schema_roundtrip.py::test_harness_loads_current_schema -v`
+Expected: PASS (proves provisioning + round-trip; if it errors on the scilit-paper insert, the harness is wrong, not the schema).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/conftest.py tests/test_schema_roundtrip.py
+git commit -m "test(scilit): scratch-DB schema round-trip harness"
+```
+
+---
+
+## Task 2: OOEVV vocabulary layer — ElementSet + elements
+
+Replace the OOEVV element definitions so an **ElementSet** is a first-class vocabulary object grouping
+its **entities** (material vs ICE), **processes** (assay/material-processing/data-transformation),
+**variables** (constant/parameter/measurement), and **scales**.
+
+**Files:**
+- Modify: `schema.tql` — replace the OOEVV element/entity definitions in the `# OOEVV + KEfED PROTOCOL-GRAPH`
+  block (current lines ~754-856); KEEP the scale subtypes (`ooevv-nominal-scale` etc., lines ~821-830) and
+  the `ooevv-*` attributes (`ooevv-definition/unit/min/max/allowed-value/named-rank`, lines ~763-768).
+- Modify: `tests/test_schema_roundtrip.py` — add the layer test.
+
+**Interfaces:**
+- Produces (new types later tasks build on): `ooevv-element-set`, `ooevv-element` (base),
+  `ooevv-material-entity`, `ooevv-variable` (owns `ooevv-variable-role`, `ooevv-ice-kind`, `kefed-efo-label`),
+  `ooevv-process` + subtypes `ooevv-assay` / `ooevv-material-processing` / `ooevv-data-transformation`,
+  `ooevv-scale` (+ existing subtypes). Relation `ooevv-set-element(element-set, element)`.
+
+- [ ] **Step 1: Write the failing layer test**
+
+Add to `tests/test_schema_roundtrip.py`:
+
+```python
+def test_ooevv_elementset_and_elements(scratch_db):
+    w(scratch_db,
+      'insert $s isa ooevv-element-set, has id "ooevv-es-rnaseq", has name "RNASeq",'
+      '  has ooevv-definition "vocabulary for RNASeq experiments";')
+    # a material entity, a measurement variable, an assay process, a numeric scale, all in the set
+    w(scratch_db,
+      'match $s isa ooevv-element-set, has id "ooevv-es-rnaseq";'
+      'insert $m isa ooevv-material-entity, has id "ooevv-me-mouse", has name "mouse";'
+      ' (element-set: $s, element: $m) isa ooevv-set-element;')
+    w(scratch_db,
+      'match $s isa ooevv-element-set, has id "ooevv-es-rnaseq";'
+      'insert $v isa ooevv-variable, has id "ooevv-var-expr", has name "expression",'
+      '  has ooevv-variable-role "measurement", has ooevv-ice-kind "measurement",'
+      '  has kefed-efo-label "EFO:0000001";'
+      ' (element-set: $s, element: $v) isa ooevv-set-element;')
+    w(scratch_db,
+      'match $s isa ooevv-element-set, has id "ooevv-es-rnaseq";'
+      'insert $a isa ooevv-assay, has id "ooevv-assay-qpcr", has name "qPCR";'
+      ' (element-set: $s, element: $a) isa ooevv-set-element;')
+    rows = r(scratch_db,
+      'match $s isa ooevv-element-set, has id "ooevv-es-rnaseq";'
+      ' (element-set: $s, element: $e) isa ooevv-set-element; $e has name $n; fetch {"n": $n};')
+    names = sorted(x["n"] for x in rows)
+    assert names == ["expression", "mouse", "qPCR"]
+    # role + ice-kind round-trip on the variable
+    vr = r(scratch_db, 'match $v isa ooevv-variable, has id "ooevv-var-expr", has ooevv-variable-role $role,'
+                       ' has ooevv-ice-kind $k; fetch {"role": $role, "k": $k};')
+    assert vr[0]["role"] == "measurement" and vr[0]["k"] == "measurement"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run --python 3.12 pytest tests/test_schema_roundtrip.py::test_ooevv_elementset_and_elements -v`
+Expected: FAIL — `ooevv-element-set` / `ooevv-material-entity` / `ooevv-variable` types do not exist yet.
+
+- [ ] **Step 3: Add the schema (replace the OOEVV element block)**
+
+In `schema.tql`, within the OOEVV protocol-graph block, add these BEFORE the entities (relations first),
+and replace the old `ooevv-quality`/`ooevv-process`/standalone-entity definitions:
+
+```tql
+# --- OOEVV element vocabulary (ontological commitment for a class of experiments) ---
+attribute ooevv-variable-role, value string;   # constant | parameter | measurement
+attribute ooevv-ice-kind, value string;        # measurement | derived (for ICE variables in the bigraph)
+
+relation ooevv-set-element,                     # an element-set groups its elements
+    relates element-set, relates element;
+
+# ELEMENT - base for everything an element-set contains. (concrete parent -> not @abstract)
+entity ooevv-element sub alh-domain-thing,
+    owns ooevv-definition, owns ooevv-long-form, owns scilit-curie,
+    plays ooevv-set-element:element;
+
+# ELEMENT-SET - the reusable vocabulary commitment for a CLASS of experiments (e.g. "RNASeq").
+entity ooevv-element-set sub alh-artifact,
+    owns ooevv-definition,
+    plays ooevv-set-element:element-set;
+
+# ENTITY split: material entity (obo:BFO_0000040) vs information content entity (obo:IAO_0000030).
+entity ooevv-material-entity sub ooevv-element;        # obo:BFO_0000040
+# VARIABLE - an ICE that takes values (obo:IAO_0000030); definitions ground to EFO via kefed-efo-label.
+entity ooevv-variable sub ooevv-element,               # obo:IAO_0000030
+    owns ooevv-variable-role,
+    owns ooevv-ice-kind,
+    owns kefed-efo-label,
+    owns scilit-grounding-label, owns scilit-grounding-state, owns scilit-grounding-confidence,
+    plays ooevv-measures:measured-variable,
+    plays ooevv-has-scale:scaled-variable,
+    plays ooevv-scale-parts:part-variable;
+
+# PROCESS - a protocol step (obo:BFO_0000015); subtypes carry their OBI curie.
+entity ooevv-process sub ooevv-element;                # obo:BFO_0000015
+entity ooevv-assay sub ooevv-process;                  # obo:OBI_0000070
+entity ooevv-material-processing sub ooevv-process;    # obo:OBI_0000094
+entity ooevv-data-transformation sub ooevv-process;    # obo:OBI_0200000
+
+# SCALE - the computational type of a variable's values (keep OOEVV's own taxonomy).
+entity ooevv-scale sub ooevv-element,
+    owns ooevv-unit,
+    plays ooevv-has-scale:scale;
+entity ooevv-nominal-scale sub ooevv-scale, owns ooevv-allowed-value @card(0..);
+entity ooevv-binary-scale sub ooevv-scale, owns ooevv-allowed-value @card(0..);
+entity ooevv-ordinal-scale sub ooevv-scale, owns ooevv-named-rank @card(0..);
+entity ooevv-numeric-scale sub ooevv-scale, owns ooevv-min, owns ooevv-max;
+entity ooevv-file-scale sub ooevv-scale;
+entity ooevv-composite-scale sub ooevv-scale, plays ooevv-scale-parts:composite-scale;
+```
+
+Keep the existing `ooevv-measures` / `ooevv-has-scale` / `ooevv-scale-parts` relations (they still apply,
+now to `ooevv-variable`). Remove the old `ooevv-quality` entity and the old standalone `ooevv-process`
+plays-list (the bigraph plays are re-added in Task 3). Delete the `kefed-variable`-based plays-extensions
+at lines ~833-856 (superseded by `ooevv-variable`).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run --python 3.12 pytest tests/test_schema_roundtrip.py::test_ooevv_elementset_and_elements -v`
+Expected: PASS. (If TypeDB reports an unresolved `plays`, ensure the `ooevv-measures`/`ooevv-has-scale`/
+`ooevv-scale-parts` relations are declared above these entities.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add schema.tql tests/test_schema_roundtrip.py
+git commit -m "feat(scilit): OOEVV element-set + element vocabulary (un-fuse from kefed-model)"
+```
+
+---
+
+## Task 3: KEfED model — the entity-process bigraph
+
+Define `kefed-model` as **just the bigraph** (built from one element-set): material-flow I/O edges,
+parameter binding on BOTH entities and processes, an explicit subject role, and measurement-vs-derived
+ICE typing via the producing process.
+
+**Files:**
+- Modify: `schema.tql` — replace `kefed-model`/`kefed-element`/`kefed-observed-via` (lines ~440-447, 513-529)
+  and the protocol-graph relations (lines ~778-796) with the bigraph below.
+- Modify: `tests/test_schema_roundtrip.py`.
+
+**Interfaces:**
+- Produces: `kefed-model` (entity, sub `alh-artifact`); relations `kefed-model-element(model, element)`,
+  `ooevv-process-input(input-entity, consuming-process)`, `ooevv-process-output(producing-process, output-entity)`,
+  `ooevv-parameter-binding(binding-bearer, bound-parameter)` where `binding-bearer` is played by BOTH
+  `ooevv-process` AND `ooevv-material-entity`, `ooevv-subject(model, subject-entity)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_schema_roundtrip.py`:
+
+```python
+def _seed_elementset(db):
+    w(db, 'insert $s isa ooevv-element-set, has id "ooevv-es-x", has name "X";')
+
+def test_kefed_bigraph(scratch_db):
+    _seed_elementset(scratch_db)
+    # model + subject material entity + a manipulation process + a measurement variable
+    w(scratch_db, 'insert $m isa kefed-model, has id "kefedm-1", has name "qPCR run",'
+                  '  has content "protocol", has format "kefed-bigraph";')
+    w(scratch_db, 'match $m isa kefed-model, has id "kefedm-1";'
+                  'insert $subj isa ooevv-material-entity, has id "me-subj", has name "mouse";'
+                  ' (model: $m, subject-entity: $subj) isa ooevv-subject;')
+    w(scratch_db, 'match $subj isa ooevv-material-entity, has id "me-subj";'
+                  'insert $p isa ooevv-material-processing, has id "mp-1", has name "knockout";'
+                  ' (input-entity: $subj, consuming-process: $p) isa ooevv-process-input;')
+    # a treatment parameter bound at the manipulation process AND a genotype param on the entity
+    w(scratch_db, 'match $p isa ooevv-material-processing, has id "mp-1";'
+                  'insert $par isa ooevv-variable, has id "var-treat", has name "treatment",'
+                  '  has ooevv-variable-role "parameter";'
+                  ' (binding-bearer: $p, bound-parameter: $par) isa ooevv-parameter-binding;')
+    w(scratch_db, 'match $subj isa ooevv-material-entity, has id "me-subj";'
+                  'insert $g isa ooevv-variable, has id "var-geno", has name "genotype",'
+                  '  has ooevv-variable-role "parameter";'
+                  ' (binding-bearer: $subj, bound-parameter: $g) isa ooevv-parameter-binding;')
+    # subject reads back
+    sj = r(scratch_db, 'match $m isa kefed-model, has id "kefedm-1";'
+                       ' (model: $m, subject-entity: $e) isa ooevv-subject; $e has name $n; fetch {"n": $n};')
+    assert sj[0]["n"] == "mouse"
+    # BOTH a process and an entity bear a parameter
+    bearers = r(scratch_db, 'match (binding-bearer: $b, bound-parameter: $par) isa ooevv-parameter-binding;'
+                            ' $par has name $pn; fetch {"pn": $pn};')
+    assert sorted(x["pn"] for x in bearers) == ["genotype", "treatment"]
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run --python 3.12 pytest tests/test_schema_roundtrip.py::test_kefed_bigraph -v`
+Expected: FAIL — `kefed-model` bigraph roles / `ooevv-subject` / dual `binding-bearer` not defined.
+
+- [ ] **Step 3: Add the schema (the bigraph)**
+
+In `schema.tql`, replace the old `kefed-element`/`kefed-observed-via`/`kefed-model`/`kefed-variable`
+definitions and the old protocol-graph relations with:
+
+```tql
+# --- KEfED bigraph: entities <-> processes, parameters borne by both ---
+relation kefed-model-element,                   # a model groups the elements that form its bigraph
+    relates model, relates element;
+relation ooevv-subject,                         # the model's SOURCE node (experimental subject)
+    relates model, relates subject-entity;
+relation ooevv-process-input,                   # material flow: entity consumed by a process
+    relates input-entity, relates consuming-process;
+relation ooevv-process-output,                  # material flow: entity produced by a process
+    relates producing-process, relates output-entity;
+relation ooevv-parameter-binding,               # a parameter is set ON a process OR an entity (KEfED dependency)
+    relates binding-bearer, relates bound-parameter;
+relation ooevv-parameter-target,                # a parameter's value targets a curated entity (specificity)
+    relates targeting-parameter, relates target-entity;
+relation ooevv-produced-by,                     # a measurement/derived variable is produced by a process
+    relates produced-variable, relates producing-process;
+
+# KEFED-MODEL - the bigraph (built from one element-set). No ElementSet fusion, no slots.
+entity kefed-model sub alh-artifact,
+    plays kefed-model-element:model,
+    plays ooevv-subject:model;
+
+# bigraph plays for processes/entities/variables
+entity ooevv-process
+    plays kefed-model-element:element,
+    plays ooevv-process-input:consuming-process,
+    plays ooevv-process-output:producing-process,
+    plays ooevv-parameter-binding:binding-bearer,
+    plays ooevv-produced-by:producing-process;
+entity ooevv-material-entity
+    plays kefed-model-element:element,
+    plays ooevv-subject:subject-entity,
+    plays ooevv-process-input:input-entity,
+    plays ooevv-process-output:output-entity,
+    plays ooevv-parameter-binding:binding-bearer,   # entities ALSO bear parameters
+    plays ooevv-parameter-target:target-entity;
+entity ooevv-variable
+    plays kefed-model-element:element,
+    plays ooevv-parameter-binding:bound-parameter,
+    plays ooevv-parameter-target:targeting-parameter,
+    plays ooevv-produced-by:produced-variable;
+```
+
+Delete `kefed-variable`, `kefed-element`, `kefed-observed-via`, `kefed-variable-role`, `kefed-value-set`
+(superseded by `ooevv-variable` + `ooevv-variable-role`). Keep `kefed-efo-label` (now owned by `ooevv-variable`).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run --python 3.12 pytest tests/test_schema_roundtrip.py::test_kefed_bigraph -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add schema.tql tests/test_schema_roundtrip.py
+git commit -m "feat(scilit): kefed-model as entity-process bigraph; parameters on entities and processes; subject role"
+```
+
+---
+
+## Task 4: Data-transformation parameter-mapping rules
+
+A `ooevv-data-transformation` declares typed rules for how its input parameters map to output parameters,
+so a derived datum's index composes through the workflow (full provenance).
+
+**Files:**
+- Modify: `schema.tql` — add the mapping-rule relation + attribute near the process definitions.
+- Modify: `tests/test_schema_roundtrip.py`.
+
+**Interfaces:**
+- Produces: attribute `ooevv-param-rule-kind` (`passthrough` | `aggregate-collapse-destroy` | `combine` |
+  `derive`); relation `ooevv-param-mapping(transformation, in-parameter, out-parameter)` owning
+  `ooevv-param-rule-kind`. (`in-parameter`/`out-parameter` played by `ooevv-variable`.)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_param_mapping_rules(scratch_db):
+    w(scratch_db, 'insert $t isa ooevv-data-transformation, has id "dt-mean", has name "mean over replicates";')
+    w(scratch_db, 'insert $i isa ooevv-variable, has id "var-rep", has name "replicate", has ooevv-variable-role "parameter";')
+    w(scratch_db, 'insert $o isa ooevv-variable, has id "var-mean", has name "mean-expr", has ooevv-variable-role "measurement", has ooevv-ice-kind "derived";')
+    # mean DESTROYS the replicate index: in-parameter present, out-parameter absent, kind=aggregate-collapse-destroy
+    w(scratch_db, 'match $t isa ooevv-data-transformation, has id "dt-mean";'
+                  ' $i isa ooevv-variable, has id "var-rep";'
+                  'insert (transformation: $t, in-parameter: $i) isa ooevv-param-mapping,'
+                  '  has ooevv-param-rule-kind "aggregate-collapse-destroy";')
+    rows = r(scratch_db, 'match (transformation: $t, in-parameter: $i) isa ooevv-param-mapping,'
+                         '  has ooevv-param-rule-kind $k; $i has name $n; fetch {"k": $k, "n": $n};')
+    assert rows[0]["k"] == "aggregate-collapse-destroy" and rows[0]["n"] == "replicate"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run --python 3.12 pytest tests/test_schema_roundtrip.py::test_param_mapping_rules -v`
+Expected: FAIL — `ooevv-param-mapping` / `ooevv-param-rule-kind` undefined.
+
+- [ ] **Step 3: Add the schema**
+
+```tql
+attribute ooevv-param-rule-kind, value string;  # passthrough | aggregate-collapse-destroy | combine | derive
+
+# how a data-transformation maps an input parameter to an output parameter (or destroys it).
+relation ooevv-param-mapping,
+    relates transformation,
+    relates in-parameter @card(0..),
+    relates out-parameter @card(0..),
+    owns ooevv-param-rule-kind;
+
+entity ooevv-data-transformation plays ooevv-param-mapping:transformation;
+entity ooevv-variable plays ooevv-param-mapping:in-parameter,
+    plays ooevv-param-mapping:out-parameter;
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run --python 3.12 pytest tests/test_schema_roundtrip.py::test_param_mapping_rules -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add schema.tql tests/test_schema_roundtrip.py
+git commit -m "feat(scilit): typed data-transformation parameter-mapping rules"
+```
+
+---
+
+## Task 5: Template/instance + data table + warrant
+
+Template = a `kefed-model` with no instantiated variables (a state, not a new type). A `kefed-instance`
+records one paper's value-instantiations (data rows) + warrant. Retire `kefed-slot` / `kefed-template`.
+
+**Files:**
+- Modify: `schema.tql` — replace the `kefed-template`/`kefed-slot`/`kefed-instance`/`ooevv-datum`/`ooevv-cell`
+  block (lines ~860-931) with the reconfigured instance/data/warrant layer.
+- Modify: `tests/test_schema_roundtrip.py`.
+
+**Interfaces:**
+- Produces: attribute `kefed-model-state` (`template` | `instantiated`) on `kefed-model`; entity
+  `kefed-instance` (sub `alh-artifact`); relations `ooevv-instance-of(instance, model)`,
+  `ooevv-instance-datum(instance, datum)`, `ooevv-cell(datum, cell-variable)` owning
+  `ooevv-cell-value`/`ooevv-cell-number`, `ooevv-datum-observation(datum, observation)`; entity
+  `ooevv-datum`; attribute `scilit-warrant` on `kefed-instance`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_instance_data_and_warrant(scratch_db):
+    w(scratch_db, 'insert $m isa kefed-model, has id "kefedm-t", has name "design", has kefed-model-state "template";')
+    w(scratch_db, 'insert $v isa ooevv-variable, has id "v-expr", has name "expr", has ooevv-variable-role "measurement";')
+    w(scratch_db, 'match $m isa kefed-model, has id "kefedm-t";'
+                  'insert $inst isa kefed-instance, has id "kefedi-1", has name "paperA run",'
+                  '  has scilit-warrant "supports a WT-vs-KO contrast";'
+                  ' (instance: $inst, model: $m) isa ooevv-instance-of;')
+    w(scratch_db, 'match $inst isa kefed-instance, has id "kefedi-1"; $v isa ooevv-variable, has id "v-expr";'
+                  'insert $d isa ooevv-datum, has id "dat-1";'
+                  ' (instance: $inst, datum: $d) isa ooevv-instance-datum;'
+                  ' (datum: $d, cell-variable: $v) isa ooevv-cell, has ooevv-cell-value "12.3", has ooevv-cell-number 12.3;')
+    rows = r(scratch_db, 'match $inst isa kefed-instance, has id "kefedi-1", has scilit-warrant $war;'
+                         ' (instance: $inst, datum: $d) isa ooevv-instance-datum;'
+                         ' (datum: $d, cell-variable: $v) isa ooevv-cell, has ooevv-cell-number $num;'
+                         ' fetch {"war": $war, "num": $num};')
+    assert rows[0]["war"].startswith("supports") and rows[0]["num"] == 12.3
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run --python 3.12 pytest tests/test_schema_roundtrip.py::test_instance_data_and_warrant -v`
+Expected: FAIL — `kefed-model-state` / `kefed-instance` / `ooevv-instance-of` undefined.
+
+- [ ] **Step 3: Add the schema**
+
+```tql
+attribute kefed-model-state, value string;   # template (no values bound) | instantiated
+attribute scilit-warrant, value string;       # what the instance's data licenses (derived from index sets)
+attribute ooevv-cell-value, value string;
+attribute ooevv-cell-number, value double;
+
+entity kefed-model owns kefed-model-state;
+
+relation ooevv-instance-of, relates instance, relates model;
+relation ooevv-instance-datum, relates instance, relates datum;
+relation ooevv-cell, relates datum, relates cell-variable, owns ooevv-cell-value, owns ooevv-cell-number;
+relation ooevv-datum-observation, relates datum, relates observation;
+
+# INSTANCE - one paper's execution of a model: value-instantiations (data rows) + warrant.
+entity kefed-instance sub alh-artifact,
+    owns scilit-warrant,
+    plays ooevv-instance-of:instance,
+    plays ooevv-instance-datum:instance;
+# DATUM - one data row; cells hold per-variable values; links to its provenance observation.
+entity ooevv-datum sub alh-domain-thing,
+    plays ooevv-instance-datum:datum,
+    plays ooevv-cell:datum,
+    plays ooevv-datum-observation:datum;
+
+entity kefed-model plays ooevv-instance-of:model;
+entity ooevv-variable plays ooevv-cell:cell-variable;
+```
+
+Delete `kefed-template`, `kefed-slot`, `kefed-template-slot`, `ooevv-param-slot`, `ooevv-slot-binding`,
+`kefed-slot-role`, `kefed-slot-kind` (slots fold into uninstantiated `ooevv-variable`s). Keep
+`scilit-observation` plays `ooevv-datum-observation:observation` (re-declared in Task 6).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run --python 3.12 pytest tests/test_schema_roundtrip.py::test_instance_data_and_warrant -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add schema.tql tests/test_schema_roundtrip.py
+git commit -m "feat(scilit): template=uninstantiated model; instance carries data table + warrant; retire kefed-slot"
+```
+
+---
+
+## Task 6: Rhetorical layer — span-anchored claims, AZ, hinges, gaps
+
+One claim type, span-anchored to verbatim fragments, with an AZ property; typed hinges/gaps; the
+claim->observation->measurement provenance chain. Retire the `scilit-claim`/`scilit-gap` legacy aliases.
+
+**Files:**
+- Modify: `schema.tql` — consolidate `scilit-reported-claim`/`scilit-reported-gap`/`scilit-observation`/
+  `scilit-hinge`/`scilit-addresses` onto the clean rhetorical model; ensure span-anchoring via the existing
+  `alh-derivation` (note->fragment) + fragment `offset`/`length`.
+- Modify: `tests/test_schema_roundtrip.py`.
+
+**Interfaces:**
+- Produces: `scilit-claim` (sub `alh-sensemaking-note`, owns `scilit-claim-statement`, `scilit-claim-type`,
+  `scilit-rhetorical-role`); `scilit-gap` (owns `scilit-knowledge-goal`); relations
+  `scilit-claim-observation(claim, observation)`, `scilit-hinge(hinging-claim, hinged-to)` owning
+  `scilit-hinge-term-id`, `scilit-addresses(addressing-note, gap)`; claims/observations play
+  `alh-derivation:derivative` (anchored to `alh-fragment` source).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_rhetorical_span_anchored(scratch_db):
+    # a paper + cached-less fragment (offset/length present), a claim anchored to it, AZ + hinge + obs link
+    w(scratch_db, 'insert $p isa scilit-paper, has id "scilit-paper-r", has name "paperR";')
+    w(scratch_db, 'insert $f isa scilit-sentence, has id "frag-1", has content "SIRT3 is required.", has offset 100, has length 18;')
+    w(scratch_db, 'insert $c isa scilit-claim, has id "claim-1", has name "SIRT3 necessity",'
+                  '  has scilit-claim-statement "SIRT3 is required for X", has scilit-claim-type "primary",'
+                  '  has scilit-rhetorical-role "own-claim";')
+    w(scratch_db, 'match $c isa scilit-claim, has id "claim-1"; $f isa scilit-sentence, has id "frag-1";'
+                  'insert (derivative: $c, derived-from-source: $f) isa alh-derivation;')
+    w(scratch_db, 'insert $o isa scilit-observation, has id "obs-1", has name "obs",'
+                  '  has scilit-knowledge-level "association", has scilit-bio-scale "cellular";')
+    w(scratch_db, 'match $c isa scilit-claim, has id "claim-1"; $o isa scilit-observation, has id "obs-1";'
+                  'insert (claim: $c, observation: $o) isa scilit-claim-observation;')
+    # claim -> anchored fragment offset
+    rows = r(scratch_db, 'match $c isa scilit-claim, has id "claim-1", has scilit-rhetorical-role $az;'
+                         ' (derivative: $c, derived-from-source: $f) isa alh-derivation;'
+                         ' $f has offset $off, has length $len; fetch {"az": $az, "off": $off, "len": $len};')
+    assert rows[0]["az"] == "own-claim" and rows[0]["off"] == 100 and rows[0]["len"] == 18
+    # claim -> observation provenance hop
+    obs = r(scratch_db, 'match (claim: $c, observation: $o) isa scilit-claim-observation; $o has id $oid; fetch {"oid": $oid};')
+    assert obs[0]["oid"] == "obs-1"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run --python 3.12 pytest tests/test_schema_roundtrip.py::test_rhetorical_span_anchored -v`
+Expected: FAIL — `scilit-claim` / `scilit-claim-observation` not defined under the clean model.
+
+- [ ] **Step 3: Add the schema**
+
+Reconcile the rhetorical block so a single `scilit-claim` exists (rename `scilit-reported-claim` ->
+`scilit-claim`, `scilit-reported-gap` -> `scilit-gap`), each span-anchored:
+
+```tql
+attribute scilit-claim-type, value string;        # primary | secondary | peripheral
+attribute scilit-claim-statement, value string;
+# (scilit-rhetorical-role, scilit-knowledge-goal, scilit-knowledge-level, scilit-bio-scale,
+#  scilit-hinge-term-id already declared earlier in schema.tql — reuse.)
+
+relation scilit-claim-observation,                 # claim <- supporting observation (provenance grounds)
+    relates claim, relates observation;
+
+entity scilit-claim sub alh-sensemaking-note,
+    owns scilit-claim-type, owns scilit-claim-statement, owns scilit-rhetorical-role,
+    plays scilit-claim-observation:claim,
+    plays scilit-hinge:hinging-claim, plays scilit-hinge:hinged-to,
+    plays scilit-addresses:addressing-note,
+    plays alh-derivation:derivative;                # span-anchored to fragments
+entity scilit-gap sub alh-sensemaking-note,
+    owns scilit-knowledge-goal,
+    plays scilit-addresses:gap;
+entity scilit-observation
+    plays scilit-claim-observation:observation,
+    plays ooevv-datum-observation:observation,
+    plays alh-derivation:derivative;                # observations are span-anchored too
+```
+
+Delete `scilit-reported-claim`, `scilit-reported-gap`, and their `scilit-sensemaking-reported-*` relations;
+re-point any other relations that referenced them to `scilit-claim`/`scilit-gap`. Ensure `scilit-paper`
+still plays `scilit-hinge:hinged-to` (paper-level citation).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run --python 3.12 pytest tests/test_schema_roundtrip.py::test_rhetorical_span_anchored -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add schema.tql tests/test_schema_roundtrip.py
+git commit -m "feat(scilit): unified span-anchored scilit-claim/gap with AZ + provenance chain"
+```
+
+---
+
+## Task 7: Investigation + first-class iterations
+
+An investigation owns an ordered sequence of `scilit-iteration` objects; each iteration owns a corpus
+configuration and its five stage notes.
+
+**Files:**
+- Modify: `schema.tql` — add the iteration layer; re-point stage threading from investigation to iteration.
+- Modify: `tests/test_schema_roundtrip.py`.
+
+**Interfaces:**
+- Produces: entity `scilit-iteration` (sub `alh-note`, owns `scilit-iteration-index` (integer)); relations
+  `scilit-investigation-iteration(investigation, iteration)`, `scilit-iteration-corpus(iteration, corpus)`,
+  `scilit-iteration-stage(iteration, stage)`; `scilit-investigation-phase` re-typed to play `iteration-stage:stage`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_investigation_iterations(scratch_db):
+    w(scratch_db, 'insert $i isa scilit-investigation, has id "scinv-1", has name "inv", has content "goal";')
+    w(scratch_db, 'insert $c isa scilit-corpus, has id "collection-1", has name "corpus";')
+    w(scratch_db, 'match $i isa scilit-investigation, has id "scinv-1";'
+                  'insert $it isa scilit-iteration, has id "scit-1", has name "iteration 1", has scilit-iteration-index 1;'
+                  ' (investigation: $i, iteration: $it) isa scilit-investigation-iteration;')
+    w(scratch_db, 'match $it isa scilit-iteration, has id "scit-1"; $c isa scilit-corpus, has id "collection-1";'
+                  'insert (iteration: $it, corpus: $c) isa scilit-iteration-corpus;')
+    w(scratch_db, 'match $it isa scilit-iteration, has id "scit-1";'
+                  'insert $ph isa scilit-investigation-phase, has id "scph-1", has name "discovery", has scilit-phase "discovery";'
+                  ' (iteration: $it, stage: $ph) isa scilit-iteration-stage;')
+    rows = r(scratch_db, 'match $i isa scilit-investigation, has id "scinv-1";'
+                         ' (investigation: $i, iteration: $it) isa scilit-investigation-iteration;'
+                         ' $it has scilit-iteration-index $idx;'
+                         ' (iteration: $it, stage: $ph) isa scilit-iteration-stage; $ph has scilit-phase $stage;'
+                         ' fetch {"idx": $idx, "stage": $stage};')
+    assert rows[0]["idx"] == 1 and rows[0]["stage"] == "discovery"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run --python 3.12 pytest tests/test_schema_roundtrip.py::test_investigation_iterations -v`
+Expected: FAIL — `scilit-iteration` / `scilit-investigation-iteration` undefined.
+
+- [ ] **Step 3: Add the schema**
+
+```tql
+attribute scilit-iteration-index, value integer;
+
+relation scilit-investigation-iteration,        # investigation owns an ordered list of iterations
+    relates investigation, relates iteration;
+relation scilit-iteration-corpus,               # an iteration's corpus configuration (its paper set for the round)
+    relates iteration, relates corpus;
+relation scilit-iteration-stage,                # an iteration owns its 5 stage notes
+    relates iteration, relates stage;
+
+entity scilit-iteration sub alh-note,
+    owns scilit-iteration-index,
+    plays scilit-investigation-iteration:iteration,
+    plays scilit-iteration-corpus:iteration,
+    plays scilit-iteration-stage:iteration;
+entity scilit-investigation plays scilit-investigation-iteration:investigation;
+entity scilit-corpus plays scilit-iteration-corpus:corpus;
+entity scilit-investigation-phase plays scilit-iteration-stage:stage;
+```
+
+Remove the old `scilit-investigation-phasing` (investigation->phase) wiring superseded by iteration->stage.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run --python 3.12 pytest tests/test_schema_roundtrip.py::test_investigation_iterations -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add schema.tql tests/test_schema_roundtrip.py
+git commit -m "feat(scilit): first-class investigation iterations owning corpus-config + stage notes"
+```
+
+---
+
+## Task 8: Full-schema load gate + retirement sweep
+
+Confirm the whole reconfigured `schema.tql` loads cleanly with NO references to retired types, and the
+full layer suite passes together.
+
+**Files:**
+- Modify: `schema.tql` — grep-and-remove any lingering references to retired types.
+- Modify: `tests/test_schema_roundtrip.py` — add a guard test.
+
+- [ ] **Step 1: Write the retirement guard test**
+
+```python
+def test_no_retired_types_remain():
+    import re, pathlib
+    txt = pathlib.Path(__file__).resolve().parent.parent.joinpath("schema.tql").read_text()
+    retired = ["kefed-slot", "kefed-template ", "kefed-variable", "kefed-element ",
+               "kefed-observed-via", "scilit-reported-claim", "scilit-reported-gap", "ooevv-quality"]
+    present = [t for t in retired if t in txt]
+    assert not present, f"retired types still referenced: {present}"
+```
+
+- [ ] **Step 2: Run the full DB-backed suite (all layers together)**
+
+Run: `uv run --python 3.12 pytest tests/test_schema_roundtrip.py -v`
+Expected: every layer test PASSES and `test_no_retired_types_remain` PASSES. Fix any lingering retired
+reference in `schema.tql` that the guard or a load error surfaces.
+
+- [ ] **Step 3: Confirm a clean full load via alhazen-core (mirrors the SessionStart hook)**
+
+Run:
+```bash
+TYPEDB_DATABASE=alh_scilit_schema_test uv run --project ~/skillful-alhazen/local_skills/alhazen-core \
+  python ~/skillful-alhazen/local_skills/alhazen-core/alhazen_core.py load-schema \
+  ~/Documents/GitHub/alhazen-skill-deep-research/skills/scientific-literature/schema.tql
+```
+Expected: `{"success": true, ... "schema": "loaded"}` with no `[DEX*]`/`[SYR*]` errors.
+
+- [ ] **Step 4: Run the existing pure-logic unit tests (no regressions)**
+
+Run: `uv run --python 3.12 pytest tests/ -v --ignore=tests/test_schema_roundtrip.py`
+Expected: existing `test_paper_identity` / `test_entity_identity` / `test_grounding_qc` /
+`test_cluster_synthesis` / `test_ontology_grounding` / `test_upsert_paper` all PASS unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add schema.tql tests/test_schema_roundtrip.py
+git commit -m "chore(scilit): retirement sweep + full reconfigured schema load gate"
+```
+
+---
+
+## Follow-on plans (Sub-project 1, after this lands)
+
+- **Plan 2 — `kqed.py` + CLI re-alignment.** Reconfigure `kqed.py` authoring verbs (`add_kefed_model` ->
+  bigraph builder, `add_observation` without `kefed-observed-via`, drop `scilit-claim`/`scilit-gap` drift,
+  add element-set / instance / param-mapping / iteration authoring) and the `scientific_literature.py`
+  `cmd_*` / `_load_*` handlers to read/write the clean model. Each verb gets a DB-backed round-trip test
+  using the Task 1 harness.
+- **Plan 3 — Data teardown + worked-example re-curation.** `make db-export` snapshot; teardown script drops
+  the old curation-layer instances from `alh_deep_research`; re-curate the hallmarks/SIRT3 record end-to-end
+  on the clean model (element-set, bigraph, instantiated data table + warrant, span-anchored claims,
+  iteration/stage), verifying counts and round-trips.
+
+Then **Sub-project 2 — the investigation-first dashboard rewrite** (separate spec section §3 → own plan).
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** §2A OOEVV element-set -> Task 2; §2B bigraph + subject + dual param binding -> Task 3;
+  §2B parameter-mapping rules -> Task 4; §2B template=uninstantiated + data table + warrant -> Task 5;
+  §2C span-anchored claims/AZ/hinges/gaps + provenance chain -> Task 6; §2D first-class iterations -> Task 7;
+  retirement of `kefed-slot`/`kefed-observed-via`/fused `kefed-model` -> Tasks 3/5/8. CLI + data move are
+  explicitly deferred to Plans 2/3 (scope split, per writing-plans guidance).
+- **Type consistency:** role names used in tests match the relations defined in the same task
+  (`element-set`/`element`; `model`/`subject-entity`; `binding-bearer`/`bound-parameter`;
+  `transformation`/`in-parameter`/`out-parameter`; `instance`/`model`/`datum`/`cell-variable`;
+  `claim`/`observation`; `investigation`/`iteration`/`corpus`/`stage`).
+- **Open risk:** exact retirement edits in `schema.tql` depend on the current relation web; Task 8's guard
+  test + full-load gate catch any dangling `plays`/`relates` to a deleted type. If a retired type is still
+  referenced by a relation we keep, re-point that relation to its clean replacement in the same task.

--- a/docs/superpowers/plans/2026-06-30-scilit-cli-realignment.md
+++ b/docs/superpowers/plans/2026-06-30-scilit-cli-realignment.md
@@ -1,0 +1,238 @@
+# Scilit CLI/kqed Re-alignment (Sub-project 1, Plan 2 of 3) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Re-point `kqed.py` and `scientific_literature.py` — every authoring verb AND every read/`_load_*`/`show-*` handler — off the retired types and onto the clean reconfigured schema, plus add the one missing successor relation (`scilit-sensemaking-experiment`) and make investigation authoring iteration-aware. After this, the CLI writes and reads the clean model end to end.
+
+**Architecture:** Both files build TypeQL as inline f-strings against TypeDB 3.8 via `get_driver()`. We add a DB-backed authoring/read test layer (extending Plan 1's scratch-DB harness) that points the modules at a throwaway DB, calls the real functions, and asserts round-trips. Behavior-preserving where the type only renamed; structure-changing where the model changed (slots gone, bigraph, first-class iterations).
+
+**Tech Stack:** TypeDB 3.8.0, `typedb-driver>=3.8.0,<3.11`, Python 3.12, `uv`, pytest.
+
+## Global Constraints
+
+- **Upstream repo, same branch:** all edits in `~/Documents/GitHub/alhazen-skill-deep-research/skills/scientific-literature/`, branch `feat/scilit-schema-reconfiguration` (continues PR #7). Commit there.
+- **The reconfigured schema is the source of truth** (Plan 1, already on this branch). Retired type names must NOT appear in live TypeQL of either `.py` file after this plan (comments OK). Retired→new map (apply verbatim):
+
+  | Retired | New |
+  |---|---|
+  | `scilit-reported-claim` / `scilit-reported-gap` | `scilit-claim` / `scilit-gap` |
+  | `kefed-variable` (entity) | `ooevv-variable` |
+  | `kefed-variable-role` (attr) | `ooevv-variable-role` |
+  | `kefed-value-set` (attr) | (dropped — no successor) |
+  | `kefed-element(model,variable)` | `kefed-model-element(model,element)` |
+  | `ooevv-set-process(container,contained-process)` / `ooevv-set-entity(container,contained-entity)` | `kefed-model-element(model,element)` |
+  | `kefed-template` (entity) | `kefed-model` + `has kefed-model-state "template"` |
+  | `kefed-slot`/`kefed-template-slot`/`ooevv-param-slot`/`ooevv-slot-binding` + `kefed-slot-role`/`kefed-slot-kind` | (dropped — slots folded into uninstantiated `ooevv-variable`) |
+  | `kefed-observed-via(observation,model)` | (dropped — see Task 3 for the new observation↔experiment wiring) |
+  | `ooevv-bundle-experiment(bundle,experiment)` | `scilit-sensemaking-experiment(sensemaking,experiment)` (added in Task 1) |
+  | `scilit-iteration-number` (attr) | first-class `scilit-iteration` (owns `scilit-iteration-index`) |
+  | `scilit-investigation-phasing(investigation,phase)` | `scilit-investigation-iteration` + `scilit-iteration-stage` |
+
+  Role renames on KEPT relations: `ooevv-parameter-binding` `binding-process`→`binding-bearer`; `ooevv-produced-by` `produced-measurement`/`terminal-process`→`produced-variable`/`producing-process`; `ooevv-instance-of` `template`→`model`; `scilit-claim-observation` `reported-claim`→`claim`.
+- **TypeDB 3.x:** never a variable-free schema match; `delete has $v of $e;` form; fetch returns plain dicts; relation MATCH uses `links`/`(role: $x) isa T`; cannot fetch attrs off a relation var (bind in match).
+- **Tests are DB-backed and call the REAL functions** (not reimplementations) against the scratch DB, asserting via independent read queries.
+
+## File structure
+
+- `schema.tql` — Task 1 adds ONE relation (`scilit-sensemaking-experiment`) + its plays.
+- `kqed.py` — Task 2 rewrites `add_kefed_model`, `add_observation`, `add_gap`.
+- `scientific_literature.py` — Tasks 3-8 re-point the `cmd_*` and `_load_*` handlers (per the cluster inventory) and delete the obsolete slot commands + their argparse subparsers + dispatch entries.
+- `tests/conftest.py` — Task 1 adds an `authoring_db` fixture (points `kqed`/`scientific_literature` at the scratch DB).
+- `tests/test_cli_realignment.py` — NEW: DB-backed round-trip tests, one cluster per task.
+
+---
+
+## Task 1: Successor relation + authoring test harness
+
+**Files:** Modify `schema.tql`, `tests/conftest.py`; Create `tests/test_cli_realignment.py`.
+
+**Interfaces produced:** relation `scilit-sensemaking-experiment(sensemaking, experiment)` — `sensemaking` played by `scilit-paper-sensemaking`, `experiment` played by BOTH `kefed-model` and `kefed-instance`. Fixture `authoring_db` → yields a driver on the scratch DB with `kqed.DB` and `scientific_literature.TYPEDB_DATABASE` monkeypatched to it.
+
+- [ ] **Step 1: Failing test** — add to `tests/test_cli_realignment.py`:
+
+```python
+import os, sys, json, types
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from conftest import w, r, SCRATCH_DB
+
+def test_sensemaking_experiment_relation(scratch_db):
+    w(scratch_db, 'insert $b isa scilit-paper-sensemaking, has id "scsm-1", has name "bundle";')
+    w(scratch_db, 'insert $m isa kefed-model, has id "kefedm-x", has name "exp", has kefed-model-state "instantiated";')
+    w(scratch_db, 'match $b isa scilit-paper-sensemaking, has id "scsm-1"; $m isa kefed-model, has id "kefedm-x";'
+                  ' insert (sensemaking: $b, experiment: $m) isa scilit-sensemaking-experiment;')
+    w(scratch_db, 'insert $i isa kefed-instance, has id "kefedi-x", has name "run";')
+    w(scratch_db, 'match $b isa scilit-paper-sensemaking, has id "scsm-1"; $i isa kefed-instance, has id "kefedi-x";'
+                  ' insert (sensemaking: $b, experiment: $i) isa scilit-sensemaking-experiment;')
+    rows = r(scratch_db, 'match $b isa scilit-paper-sensemaking, has id "scsm-1";'
+                         ' (sensemaking: $b, experiment: $e) isa scilit-sensemaking-experiment; $e has id $eid; fetch {"eid": $eid};')
+    assert sorted(x["eid"] for x in rows) == ["kefedi-x", "kefedm-x"]
+```
+
+- [ ] **Step 2: Run, confirm FAIL** — `uv run --python 3.12 pytest tests/test_cli_realignment.py::test_sensemaking_experiment_relation -v` → relation undefined.
+- [ ] **Step 3: Schema** — add to `schema.tql` (relations block, before the entity plays):
+
+```tql
+relation scilit-sensemaking-experiment,      # a per-paper bundle groups its KEfED experiments (model/instance)
+    relates sensemaking, relates experiment;
+entity scilit-paper-sensemaking plays scilit-sensemaking-experiment:sensemaking;
+entity kefed-model plays scilit-sensemaking-experiment:experiment;
+entity kefed-instance plays scilit-sensemaking-experiment:experiment;
+```
+
+- [ ] **Step 4: Harness** — add to `tests/conftest.py` an `authoring_db` fixture:
+
+```python
+@pytest.fixture
+def authoring_db(scratch_db, monkeypatch):
+    """scratch_db + the authoring modules pointed at it, so real cmd_*/kqed.* write to the scratch DB."""
+    skill_dir = str(SKILL_DIR)
+    if skill_dir not in sys.path:
+        sys.path.insert(0, skill_dir)
+    import kqed, scientific_literature
+    monkeypatch.setattr(kqed, "DB", SCRATCH_DB)
+    monkeypatch.setattr(scientific_literature, "TYPEDB_DATABASE", SCRATCH_DB)
+    return scratch_db
+```
+(`SCRATCH_DB` and `SKILL_DIR` already exist in conftest from Plan 1; export `SCRATCH_DB` if not already module-level.)
+
+- [ ] **Step 5: Run** — both the relation test and the full `tests/test_schema_roundtrip.py` pass (schema still loads).
+- [ ] **Step 6: Commit** — `git add schema.tql tests/conftest.py tests/test_cli_realignment.py && git commit -m "feat(scilit): scilit-sensemaking-experiment successor relation + authoring test harness"`
+
+---
+
+## Task 2: kqed.py authoring rewrite (bigraph, observation, gap)
+
+**Files:** Modify `kqed.py`, `tests/test_cli_realignment.py`.
+
+`add_kefed_model`, `add_observation`, `add_gap` reference retired types AND pre-existing drift (`scilit-investigation-observation`, `scilit-investigation-gap`, `scilit-observation-subject` do not exist in the schema). Rewrite onto the clean model.
+
+**New structures:**
+- `add_kefed_model(driver, name, ...)` → insert a `kefed-model` (id, name, `has kefed-model-state "template"` when no values, else `"instantiated"`). Variables are now `ooevv-variable` (owns `ooevv-variable-role`, `kefed-efo-label`) grouped by `(model: $m, element: $v) isa kefed-model-element`. Drop `kefed-element`/`kefed-variable`/`kefed-variable-role`/`kefed-value-set`/`format "kefed-protocol"`.
+- `add_observation(driver, sensemaking_bundle, statement, knowledge_level, bio_scale, about=None, ...)` → insert a `scilit-observation` (owns `scilit-knowledge-level`, `scilit-bio-scale`), thread it under its bundle via the existing `scilit-sensemaking-observation(sensemaking, observation)` relation (NOT the nonexistent `scilit-investigation-observation`), and span-anchor/about handling via `scilit-sensemaking-paper`/`alh-derivation` as available. Drop `kefed-observed-via` and `scilit-observation-subject` entirely. (Signature changes from `investigation`/`kefed_model` to `sensemaking_bundle`; update the 1 caller if any — grep `add_observation(`.)
+- `add_gap(driver, sensemaking_bundle, category_term, knowledge_goal, provenance, statement, ...)` → insert `scilit-gap` (owns `scilit-knowledge-goal`), thread under the bundle via `scilit-sensemaking-reported-gap(sensemaking, reported-gap)`. Drop the nonexistent `scilit-investigation-gap`.
+
+- [ ] **Step 1: Failing tests** (use `authoring_db`): build a model with one parameter + one measurement variable via `add_kefed_model`, assert `kefed-model-element` links + `ooevv-variable-role` round-trip; create a bundle + `add_observation`, assert `scilit-observation` threaded under it via `scilit-sensemaking-observation`; `add_gap`, assert `scilit-gap` threaded via `scilit-sensemaking-reported-gap`. (Write concrete inserts/asserts mirroring Task 1's style, calling `kqed.add_kefed_model(authoring_db, ...)` etc.)
+- [ ] **Step 2: Run, confirm FAIL** (functions still emit retired types → query/insert errors).
+- [ ] **Step 3: Rewrite** the three functions per the new structures above. Grep `add_observation(`/`add_gap(`/`add_kefed_model(` across the repo (incl. `prototypes/`) and update any in-repo caller signatures; prototypes that are one-off seeds may be left if unused by tests, but note them.
+- [ ] **Step 4: Run** — new tests pass; `kqed.py`'s own `tests/` (if any) still pass.
+- [ ] **Step 5: Commit** — `feat(scilit): kqed authoring onto clean model (bigraph model, bundle-threaded observation/gap)`
+
+---
+
+## Task 3: RENAME-ONLY batch (claim/gap/variable renames)
+
+**Files:** Modify `scientific_literature.py`, `tests/test_cli_realignment.py`.
+
+Mechanical substitutions only (same shape). Apply the retired→new map to these handlers:
+- `cmd_add_reported_claim` (3514-3555): `scilit-reported-claim`→`scilit-claim`; `scilit-claim-observation` role `reported-claim`→`claim`.
+- `cmd_add_reported_gap` (3558-3579): `scilit-reported-gap`→`scilit-gap`.
+- `cmd_add_mechanism` (3398): `scilit-reported-claim`→`scilit-claim`.
+- `cmd_add_evidence` (3244,3249): `scilit-reported-claim`→`scilit-claim`.
+- `cmd_add_datum` (4052): cell-variable `kefed-variable`→`ooevv-variable`.
+- `_load_bundles` (2291,2293): confirm claim/gap grouping rels resolve (no type literals to change; verify).
+- `_scale_of` (2409): `kefed-variable`→`ooevv-variable`.
+
+- [ ] **Step 1: Failing tests** — call `cmd_add_reported_claim`/`cmd_add_reported_gap`/`cmd_add_datum` via a `SimpleNamespace` args against `authoring_db`, capture stdout JSON (`capsys`), and assert the inserted `scilit-claim`/`scilit-gap`/datum-cell round-trips by independent query. (These FAIL pre-change because the handlers insert retired type names.)
+- [ ] **Step 2: Run, confirm FAIL.**
+- [ ] **Step 3: Apply substitutions** (exact, per the map).
+- [ ] **Step 4: Run** — tests pass.
+- [ ] **Step 5: Commit** — `refactor(scilit): rename reported-claim/gap and kefed-variable in simple handlers`
+
+---
+
+## Task 4: KEfED bigraph authoring rework + delete obsolete slot commands
+
+**Files:** Modify `scientific_literature.py`, `tests/test_cli_realignment.py`.
+
+**Rework** (set-process/set-entity/kefed-element → `kefed-model-element`; role renames; template→model+state):
+- `cmd_add_variable` (3732-3786): type→`ooevv-variable`, attr→`ooevv-variable-role`, grouping→`kefed-model-element(model,element)`, measurement produced-by roles→`produced-variable`/`producing-process`; `ctype` template branch→`kefed-model`+state.
+- `cmd_add_process` (3671-3704): grouping `ooevv-set-process`→`kefed-model-element`; template branch→model+state; keep `ooevv-process-decomposition`/process subtypes.
+- `cmd_link_entity` (3707-3729): keep `ooevv-process-input`/`-output`; grouping `ooevv-set-entity`→`kefed-model-element`.
+- `cmd_bind_parameter` (3789-3808): `kefed-variable`→`ooevv-variable`; `ooevv-parameter-binding` role `binding-process`→`binding-bearer`.
+- `cmd_add_experiment` (3652-3668): keep `kefed-model`; bundle grouping `ooevv-bundle-experiment`→`scilit-sensemaking-experiment(sensemaking,experiment)`.
+- `cmd_ensure_template` (3815-3833) + `cmd_instantiate_template` (3982-4002): redesign onto `kefed-model`+`kefed-model-state`; `ooevv-instance-of` role `template`→`model`; instance bundle attach→`scilit-sensemaking-experiment`.
+
+**DELETE (obsolete — slots gone):** `cmd_add_slot`, `cmd_param_slot`, `cmd_bind_slot` — remove the functions, their `add_parser(...)` blocks in `main()`, and their entries in the dispatch dict. Grep to confirm no remaining references.
+
+- [ ] **Step 1: Failing tests** — drive a small bigraph through the real handlers against `authoring_db`: create a model, `cmd_add_process` (assay), `cmd_add_variable` (a measurement), `cmd_bind_parameter`, `cmd_add_experiment`; assert `kefed-model-element` membership, `ooevv-parameter-binding:binding-bearer`, and `scilit-sensemaking-experiment` all round-trip. Also assert the deleted subcommands are gone (e.g. `cmd_add_slot` not in the dispatch dict).
+- [ ] **Step 2: Run, confirm FAIL.**
+- [ ] **Step 3: Rework + delete** per above.
+- [ ] **Step 4: Run** — tests pass; full `tests/test_cli_realignment.py` + `tests/test_schema_roundtrip.py` green.
+- [ ] **Step 5: Commit** — `refactor(scilit): KEfED bigraph authoring on kefed-model-element; remove slot commands`
+
+---
+
+## Task 5: Observation/bundle authoring rework
+
+**Files:** Modify `scientific_literature.py`, `tests/test_cli_realignment.py`.
+
+- `cmd_add_observation` (3305-3362) — the largest rework. Currently inserts `kefed-model` + `kefed-observed-via` + per-var `kefed-variable`/`kefed-variable-role`/`kefed-value-set`/`kefed-element`. New: insert `scilit-observation` (knowledge-level/bio-scale) threaded under its bundle via `scilit-sensemaking-observation`; build/attach the KEfED frame as a `kefed-model` linked to the bundle via `scilit-sensemaking-experiment` with `ooevv-variable`s grouped by `kefed-model-element`; drop `kefed-observed-via`/`kefed-value-set`.
+- `cmd_create_bundle` (3272-3302) — route its `iteration` arg through the new first-class `scilit-iteration` via `_ensure_phase_note` (which Task 6 makes iteration-aware); no retired type literal here but it depends on Task 6's helper.
+- `cmd_ground_bundle` (3414-3511) — the target collector (3443-3451) walks `kefed-observed-via`+`kefed-element` and writes back `("kefed-variable", …)`; re-point to the new observation/variable wiring + `ooevv-variable`.
+
+> Order note: Task 5 depends on Task 6's iteration-aware `_ensure_phase_note`. If executing strictly in order, do Task 6 BEFORE Task 5, or stub `cmd_create_bundle`'s iteration handling and finish it after Task 6. Recommended: swap execution order to 6 then 5.
+
+- [ ] Steps 1-5 as before: failing test (create bundle → `cmd_add_observation` → assert `scilit-observation` threaded + KEfED frame via `scilit-sensemaking-experiment`, NO `kefed-observed-via`), confirm FAIL, rework, run, commit `refactor(scilit): observation/bundle authoring onto clean KEfED frame`.
+
+---
+
+## Task 6: Investigation iterations (authoring side)
+
+**Files:** Modify `scientific_literature.py`, `tests/test_cli_realignment.py`.
+
+Make the phasing chokepoint iteration-aware. New rule: a stage note belongs to a `scilit-iteration` (resolved/created by `scilit-iteration-index` under the investigation), linked via `scilit-iteration-stage`; the investigation owns iterations via `scilit-investigation-iteration`.
+- `_ensure_phase_note` (1980-2003): resolve-or-create `scilit-iteration` (by index) under the investigation; create the `scilit-investigation-phase` and link via `scilit-iteration-stage`. Drop `scilit-investigation-phasing` + `scilit-iteration-number`.
+- `cmd_record_phase` (2986-3042): existence check + upsert via the iteration path.
+- `cmd_create_investigation` (2049-2129): seed iteration 1 (`scilit-iteration` index 1 + `scilit-investigation-iteration`).
+
+- [ ] Steps 1-5: failing test (`cmd_create_investigation` then `cmd_record_phase --iteration 1 --phase discovery`; assert investigation→`scilit-iteration`(index 1)→`scilit-iteration-stage`→phase, NO `scilit-investigation-phasing`), confirm FAIL, rework, run, commit `feat(scilit): iteration-aware investigation/phase authoring`.
+
+---
+
+## Task 7: Read model rework — bundle/experiment/variable
+
+**Files:** Modify `scientific_literature.py`, `tests/test_cli_realignment.py`.
+
+Re-point readers (drop slot reads; role renames; `kefed-model-element`; new bundle-experiment rel):
+- `_load_bundle` (2299-2364): per-observation frame `kefed-observed-via`+`kefed-model`+`kefed-element`/`kefed-variable-role`/`kefed-value-set` → new observation/frame wiring + `ooevv-variable`/`ooevv-variable-role`; reported-claim hinge `scilit-reported-claim`→`scilit-claim`.
+- `_load_experiment` (2462-2497): process enum `ooevv-set-process`→`kefed-model-element`; `ooevv-parameter-binding` + `ooevv-produced-by` role renames; keep decomposition/input/output.
+- `_var_brief` (2431-2459): `kefed-variable`→`ooevv-variable`, `kefed-variable-role`→`ooevv-variable-role`; DELETE the slot block (2453-2458).
+- `_load_experiments` (2373-2383), `_load_instances` (2386-2404): `ooevv-bundle-experiment`→`scilit-sensemaking-experiment`.
+
+- [ ] Steps 1-5: build a bundle+experiment via the Task 4/5 authoring, call `_load_bundle`/`_load_experiment`, assert the assembled dict has the expected processes/variables/parameters (and no slots); confirm FAIL first; commit `refactor(scilit): read model for bundle/experiment/variable on clean schema`.
+
+---
+
+## Task 8: Read model rework — template/instance/investigation + lists
+
+**Files:** Modify `scientific_literature.py`, `tests/test_cli_realignment.py`.
+
+- `_load_template` (2513-2535): `kefed-template`→`kefed-model`(state=template); DELETE slot reads (2525-2527); variables via `kefed-model-element`.
+- `_load_instance` (2548-2594): keep `kefed-instance`; `ooevv-instance-of` role `template`→`model`; DELETE slot-binding block (2563-2569); data rows keep `ooevv-instance-datum`/`ooevv-cell`/`ooevv-datum-observation`; cell var `kefed-variable-role`→`ooevv-variable-role`.
+- `_load_investigation` (2182-2265): `scilit-iteration-number`/`scilit-investigation-phasing` → traverse `scilit-investigation-iteration`→`scilit-iteration`(index)→`scilit-iteration-stage`; sort by iteration index.
+- `_load_synthesized_claims` (2632-2637): grounding-instance join `ooevv-bundle-experiment`→`scilit-sensemaking-experiment`.
+- `cmd_list_templates` (3884-3905): template filter on `kefed-model`+state; drop slot counts; process/var counts via `kefed-model-element`; instance count role rename.
+- `cmd_audit_terms` (3949-3951): `TYPES` list `kefed-variable`→`ooevv-variable`; drop `kefed-template`/`kefed-slot`.
+
+- [ ] Steps 1-5: round-trip a template/instance + an investigation with 1 iteration + 1 phase through authoring, call `_load_template`/`_load_instance`/`_load_investigation`, assert shapes (no slots; iteration-indexed phases); confirm FAIL first; commit `refactor(scilit): read model for template/instance/investigation + lists on clean schema`.
+
+---
+
+## Task 9: Retired-type guard + full gate
+
+**Files:** Modify `tests/test_cli_realignment.py`.
+
+- [ ] **Step 1: Guard test** — assert no retired type name appears in live TypeQL of `kqed.py` or `scientific_literature.py`. Read each file, strip `#` comment lines, and assert none of the retired names (`kefed-variable`, `kefed-element`, `kefed-observed-via`, `kefed-slot`, `kefed-template`, `kefed-template-slot`, `ooevv-param-slot`, `ooevv-slot-binding`, `ooevv-bundle-experiment`, `ooevv-set-process`, `ooevv-set-entity`, `scilit-reported-claim`, `scilit-reported-gap`, `kefed-value-set`, `scilit-iteration-number`, `scilit-investigation-phasing`) appear (use precise tokens; `kefed-model-element` must NOT trip a `kefed-element` check — match `'kefed-element'` only with a non-`-model-` left boundary, or check `"isa kefed-element"`/`":model)"` patterns).
+- [ ] **Step 2: Full suite** — `uv run --python 3.12 pytest tests/ -v` — all pass (schema roundtrips + cli-realignment + pure-logic units).
+- [ ] **Step 3: Commit** — `test(scilit): guard no retired types in CLI/kqed + full gate`
+
+---
+
+## Execution notes
+- **Recommended order: 1, 2, 3, 4, 6, 5, 7, 8, 9** (Task 5 depends on Task 6's iteration-aware `_ensure_phase_note`).
+- Each task: TDD (failing DB-backed test calling the REAL function → rework → green), commit only the touched files.
+
+## Self-review
+- Spec coverage: every handler in the Part-2 inventory (Clusters 1-4) maps to a task: renames→T3; bigraph authoring + obsolete-slot removal→T4; observation/bundle→T5; iterations→T6; reads→T7/T8; kqed→T2; successor relation + harness→T1; guard→T9.
+- The one schema touch (`scilit-sensemaking-experiment`) is isolated in T1 and tested before any handler relies on it.
+- Risk: `cmd_add_observation` (T5) is the largest single rework and couples to the iteration helper (T6) — order swapped accordingly. If T5 reveals the observation↔KEfED-frame wiring needs a schema tweak, STOP and escalate (it would change Plan-1 schema).

--- a/docs/superpowers/plans/2026-06-30-scilit-kefed-model-node.md
+++ b/docs/superpowers/plans/2026-06-30-scilit-kefed-model-node.md
@@ -1,0 +1,60 @@
+# Scilit KEfED model-node redesign (Sub-project 1, Plan 2b) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Checkbox steps.
+
+**Goal:** Make a `kefed-model` a graph of **`kefed-model-node`s** — each node typed by an OOEVV definition and carrying its variables — instead of putting OOEVV definition types directly into the bigraph. This resolves the entity-authoring blocker (only `ooevv-material-entity` could play bigraph roles; nothing created it or the subject) and makes the model a clean node graph whose traversal yields the data-table signature.
+
+**Architecture:** Two layers. (1) **Definitions** = the OOEVV ElementSet vocabulary (`ooevv-material-entity`, `ooevv-process`/subtypes, `ooevv-quality`, `ooevv-variable`, scales) — reusable *types*; they STOP playing bigraph roles and instead are referenced as a node's type. (2) **Graph** = `kefed-model` groups `kefed-model-node`s; each node links to its OOEVV type and carries `ooevv-variable`s; flow edges connect nodes; the subject is the source node. Revises Part-1 schema + Part-2 bigraph authoring/reads on the same branch (`feat/scilit-schema-reconfiguration`, PR #7). The claim/rhetorical/iteration/instance-data layers are unchanged.
+
+**Tech Stack:** TypeDB 3.8, `typedb-driver>=3.8.0,<3.11`, Python 3.12, uv, pytest. Reuse the `scratch_db`/`authoring_db` harness + `w`/`r` helpers.
+
+## Global Constraints
+- UPSTREAM repo `~/Documents/GitHub/alhazen-skill-deep-research/skills/scientific-literature/`, branch `feat/scilit-schema-reconfiguration`. Commit ONLY the named files per task (never `git add -A`; don't stage `dashboard/lib.ts`/`pyproject.toml`/`uv.lock`).
+- TypeDB 3.x: `entity`/`relation`/`attribute` keywords; relations before entities that play them; subtypes do NOT redeclare inherited plays (SVL42); never a variable-free schema match; ASCII comments; `value integer` not `long`.
+- Target schema (names chosen):
+  - `entity kefed-model-node sub alh-domain-thing` — a node in a model graph.
+  - `relation kefed-node-type, relates node, relates node-type;` — node-type played by `ooevv-material-entity` + `ooevv-process` (subtypes inherit).
+  - `relation kefed-node-variable, relates node, relates variable;` — variable played by `ooevv-variable`. Folds in the retired `ooevv-parameter-binding` + `ooevv-produced-by`.
+  - `kefed-model-element(model, element)` — `element` now played by `kefed-model-node` (NOT ooevv-process/variable).
+  - `ooevv-subject(model, subject-node)`, `ooevv-process-input(input-node, consuming-node)`, `ooevv-process-output(producing-node, output-node)` — all node-played.
+  - RETIRE: `ooevv-parameter-binding`, `ooevv-produced-by`, and the direct bigraph `plays` on `ooevv-material-entity`/`ooevv-process`/`ooevv-variable` (they keep `ooevv-set-element:element`, `ooevv-measures`, `ooevv-has-scale`, and gain `kefed-node-type:node-type` / `kefed-node-variable:variable`).
+  - KEEP unchanged: `ooevv-cell(datum, cell-variable)` (cell-variable still `ooevv-variable`), `ooevv-instance-*`, `ooevv-datum-observation`, `ooevv-parameter-target` (optional — retarget `targeting-parameter`=`ooevv-variable`, `target-entity`→`target-node`=`kefed-model-node` if kept; else drop).
+
+---
+
+## Task 1: Schema — kefed-model-node graph
+**Files:** `schema.tql`, `tests/test_schema_roundtrip.py`.
+**Produces:** `kefed-model-node`; relations `kefed-node-type`, `kefed-node-variable`; node-played `kefed-model-element`/`ooevv-subject`/`ooevv-process-input`/`ooevv-process-output`.
+
+- [ ] **Step 1: Failing test** — add `test_kefed_model_node_graph`: create a `kefed-model`; a node typed as a material-entity (`kefed-node-type` → an `ooevv-material-entity` def) as the subject (`ooevv-subject`); a node typed as an assay; link them via `ooevv-process-input(input-node, consuming-node)`; attach a `measurement` `ooevv-variable` to the assay node via `kefed-node-variable` and a `parameter` variable to the subject node; assert: model→node membership, node→type, node→variable(role), and the input edge, all round-trip. (This is the data-signature scaffold: measurement node ← flow ← parameter node.)
+- [ ] **Step 2: Run → FAIL** (`kefed-model-node`/`kefed-node-type`/`kefed-node-variable` undefined).
+- [ ] **Step 3: Schema** — add `kefed-model-node` + the relations; move the bigraph `plays` from `ooevv-material-entity`/`ooevv-process`/`ooevv-variable` onto `kefed-model-node`; give the OOEVV defs `plays kefed-node-type:node-type` (material-entity + process) and `ooevv-variable plays kefed-node-variable:variable`; RETIRE `ooevv-parameter-binding` + `ooevv-produced-by` (and every `plays` of them — grep). Whole file must load (all prior roundtrip tests pass).
+- [ ] **Step 4: Run → PASS** (new test + all `tests/test_schema_roundtrip.py`).
+- [ ] **Step 5: Commit** `schema.tql` + test: `feat(scilit): kefed-model-node graph (nodes typed by OOEVV defs, carry variables)`.
+
+## Task 2: Authoring — build node graphs
+**Files:** `scientific_literature.py`, `kqed.py`, `tests/test_cli_realignment.py`.
+Re-align the bigraph authoring to create nodes typed by OOEVV definitions and attach variables:
+- `cmd_add_process`: find-or-create the OOEVV process *definition* (an `ooevv-assay`/… by name) in the model's element-set, then create a `kefed-model-node` typed by it (`kefed-node-type`) and add it to the model (`kefed-model-element`).
+- New `cmd_add-node`/`cmd_set-subject` (pick): create an entity node typed by an `ooevv-material-entity` def; mark it the model's subject (`ooevv-subject`).
+- `cmd_link_entity` → connect two `kefed-model-node`s via `ooevv-process-input`/`ooevv-process-output` (node↔node), NOT `scilit-entity`.
+- `cmd_add_variable`: create/find an `ooevv-variable` def and attach it to a node via `kefed-node-variable` (drop `kefed-model-element` for variables + the retired `ooevv-produced-by`).
+- `cmd_bind_parameter`: a parameter is a `parameter`-role variable attached to a node (`kefed-node-variable`); keep `ooevv-parameter-target` only if retained in Task 1.
+- `kqed.add_kefed_model`: build a model + its subject node + variable-bearing nodes.
+- [ ] TDD: author a small graph via the real verbs (subject entity node → assay node with a measurement variable + a parameter), assert the node graph + data-signature traversal round-trips; delete/replace the now-invalid bigraph inserts. Commit (named files only): `refactor(scilit): author kefed-model-node graphs`.
+
+## Task 3: Reads — traverse nodes
+**Files:** `scientific_literature.py`, `tests/test_cli_realignment.py`.
+- `_load_experiment`: enumerate the model's nodes (`kefed-model-element`), each with its OOEVV type (`kefed-node-type`) + attached variables (`kefed-node-variable`, with roles) + flow edges (`ooevv-process-input`/`-output`) + the subject; assemble a node-graph dict. Drop the retired `ooevv-parameter-binding`/`ooevv-produced-by` reads.
+- `_var_brief` (and any variable reader): read variables via `kefed-node-variable`.
+- [ ] TDD: author a graph, `_load_experiment` → assert nodes/types/variables/edges/subject present. Commit: `refactor(scilit): read kefed-model-node graphs`.
+
+## Task 4: Guard + gate
+**Files:** `tests/test_cli_realignment.py`, `tests/test_schema_roundtrip.py` (guard only).
+- [ ] Add `ooevv-parameter-binding`/`ooevv-produced-by` to the retired-type guards (both the schema guard and the CLI guard). Run the FULL suite `uv run --python 3.12 pytest tests/ -v` — all green. Commit: `test(scilit): guard retired bigraph relations + full gate`.
+
+## Verification
+- Full suite green; a worked node-graph (subject → assay → measurement, with a parameter) authored and read back via the real verbs; data-signature traversal (measurement node ← flow ← parameter) returns the parameter.
+
+## Self-review
+Covers: node entity + typing + variable attachment (T1); authoring incl. subject + node edges (T2); node-graph reads (T3); retired-relation guard (T4). The instance/data-cell layer (`ooevv-cell`) is unchanged — cells still reference `ooevv-variable`s, now node-attached. `scilit-entity` is no longer forced into the bigraph; it remains the grounded rhetorical/mechanism entity.

--- a/docs/superpowers/plans/2026-06-30-scilit-part3a-polish.md
+++ b/docs/superpowers/plans/2026-06-30-scilit-part3a-polish.md
@@ -1,0 +1,46 @@
+# Scilit Part 3a — definitions/element-set fix + data-signature verb + cleanup
+
+> REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Checkbox steps. Same branch `feat/scilit-schema-reconfiguration` (PR #7).
+
+**Goal:** Land the pre-re-curation code polish: (1) make OOEVV definitions first-class — `kefed-model` owns `ooevv-definition`/`ooevv-long-form` and references its element-set via a real relation (retire the `eset-{mid}` name convention); (2) add a data-signature read verb + validate `add-datum --cells` against the model's variables; (3) retire obsolete prototype seeds + dead methods. All harness-tested; NO live-DB changes (that's 3b).
+
+**Architecture:** TypeDB 3.8, inline TypeQL. Reuse the `scratch_db`/`authoring_db` harness. 3b (data teardown + SIRT3 re-curation on `alh_deep_research`) is a separate plan with a checkpoint.
+
+## Global Constraints
+- UPSTREAM repo `~/Documents/GitHub/alhazen-skill-deep-research/skills/scientific-literature/`, branch `feat/scilit-schema-reconfiguration`. Commit ONLY named files per task (never `git add -A`; don't stage `dashboard/lib.ts`/`pyproject.toml`/`uv.lock`).
+- TypeDB 3.x rules (keywords; relations before entities that play them; SVL42; ASCII comments; never a variable-free schema match; `value integer`).
+- Retired-type guards must stay green (the node-model guard names must not regress).
+
+---
+
+## Task 1: Schema — model definitions + first-class element-set link
+**Files:** `schema.tql`, `tests/test_schema_roundtrip.py`.
+- Add `entity kefed-model owns ooevv-definition, owns ooevv-long-form;` (additive owns on the existing type).
+- Add `relation kefed-model-elementset, relates model, relates element-set;` — `model` played by `kefed-model`, `element-set` played by `ooevv-element-set`. A model references exactly one element-set; an element-set MAY be shared by many models (reusable vocabulary).
+- [ ] TDD: `test_model_definition_and_elementset` — create a `kefed-model` with `ooevv-definition`+`ooevv-long-form`; link it to an `ooevv-element-set` via `kefed-model-elementset`; a SECOND model links the SAME element-set; assert both models resolve the shared element-set and the definitions round-trip. RED → schema → GREEN + full `tests/test_schema_roundtrip.py`. Commit `feat(scilit): kefed-model definitions + first-class element-set relation`.
+
+## Task 2: Authoring — use the element-set relation + persist definitions
+**Files:** `scientific_literature.py`, `kqed.py`, `tests/test_cli_realignment.py`.
+- `cmd_add_experiment`/`cmd_ensure_template`: create-or-reference an `ooevv-element-set`, link via `kefed-model-elementset` (replace the `eset-{model_id}` naming convention); persist `--definition`/`--long-form` onto the `kefed-model` (they are currently dropped). Allow `--element-set <id>` to REUSE an existing set.
+- `cmd_add_process`/`cmd_add_entity_node`/`cmd_add_variable`: find-or-create OOEVV defs in the model's element-set resolved via `kefed-model-elementset` (not `eset-{mid}`).
+- `kqed.add_kefed_model`: same — link the element-set via the relation; carry a definition.
+- [ ] TDD: author two models sharing one element-set via the relation + a defined template; assert defs persist and a def created for model A is reused (found) when model B (same element-set) adds a process of that type. Commit `refactor(scilit): author via kefed-model-elementset relation; persist model definitions`.
+
+## Task 3: Data-signature read verb + add-datum validation
+**Files:** `scientific_literature.py`, `tests/test_cli_realignment.py`.
+- New read helper `_data_signature(tx, model_id)`: for each `measurement`-role `ooevv-variable` on a node in the model, traverse the flow edges (`ooevv-process-input`/`-output`) upstream/across to collect the `parameter`/`constant`-role variables reachable — the measurement's **index set**. Return `{measurement_var_id: {name, index: [param_var...]}}`.
+- New verb `cmd_show_data_signature` (`show-data-signature --model <id>` / or `--experiment`): print the signature JSON. Wire into argparse + dispatch.
+- `cmd_add_datum`: validate that every `--cells` variable id belongs to the instance's model (via node→variable), erroring clearly on an unknown variable id.
+- [ ] TDD: author a model (subject entity node with a parameter → assay node with a measurement, flow-linked); call `_data_signature`/`cmd_show_data_signature` → assert the measurement's index includes the parameter. Author an instance + `cmd_add_datum` with a bogus cell var id → assert it errors; with valid ids → succeeds. Commit `feat(scilit): data-signature read verb + add-datum cell validation`.
+
+## Task 4: Retire obsolete methods/prototypes + guard/gate
+**Files:** `scientific_literature.py`, `kqed.py`, `prototypes/*` (delete obsolete), `tests/*`.
+- Delete/retire obsolete prototype seeds that call old signatures and are superseded (`prototypes/seed_sirt3_kqed.py` if it will be replaced by CLI re-curation in 3b — confirm; `import_deepdive.py`/`run_deepdive_import.py` if dead). Remove any dead helper methods left from the old bigraph/slot model (grep for unreferenced `cmd_*`/`_load_*` that no dispatch entry or caller uses).
+- Update the CLI guard to also assert the `eset-` name-convention string is gone from live TypeQL (now that the relation replaces it), if practical.
+- [ ] Run FULL suite `uv run --python 3.12 pytest tests/ -v` — all green. Commit `chore(scilit): retire obsolete seeds/methods + gate`.
+
+## Verification
+- Full suite green; a model authored with a definition + shared element-set; `show-data-signature` returns each measurement's indexing parameters; `add-datum` rejects unknown cell variables.
+
+## Then: Part 3b (separate, checkpoint first)
+`db-export` snapshot of `alh_deep_research` → drop the old curation-layer instances + load the reconfigured schema → re-curate the SIRT3 experiment end-to-end through the CLI verbs (element-set + defs, node graph subject→assay→measured vars, instance + data table, span-anchored claims, iteration/stage) → verify counts + a `show-data-signature`/`show-instance` round-trip. Destructive on the live DB — get Gully's go-ahead before running.

--- a/docs/superpowers/plans/2026-06-30-scilit-part3b-runbook.md
+++ b/docs/superpowers/plans/2026-06-30-scilit-part3b-runbook.md
@@ -1,0 +1,87 @@
+# Scilit Part 3b — RUNBOOK: in-place reconcile of `alh_deep_research` + re-curate SIRT3
+
+> **This is a self-contained runbook for a FRESH session.** Read it top to bottom, then execute. It is the last phase of the scientific-literature reconfiguration. Everything BEFORE 3b (the code) is already done, reviewed, and on PR #7 — 3b only touches the LIVE database + curates data through the (already re-aligned) CLI verbs.
+
+## 0. Orient first (do this before anything)
+- **Work branch:** `feat/scilit-schema-reconfiguration` in the UPSTREAM skill repo `/Users/gullyburns/Documents/GitHub/alhazen-skill-deep-research/skills/scientific-literature/` (symlinked as `local_skills/scientific-literature`). HEAD should be `0d33677` or later. This is PR #7 (`sciknow-io/alhazen-skill-deep-research`).
+- **Progress ledger (READ IT):** `/Users/gullyburns/skillful-alhazen/.superpowers/sdd/progress.md` — the full record of Parts 1/2/2b/3a. Trust it + `git log` over memory.
+- **State of the code:** Part 1 (schema reconfiguration) + Part 2 (CLI/kqed re-alignment) + Plan 2b (kefed-model-node graph) + Plan 3a (definitions/element-set + data-signature verb + cleanup) are ALL complete and reviewed. **67/67 tests pass** (`cd <skill dir> && uv run --python 3.12 pytest tests/ -v`). The reconfigured `schema.tql` and the re-aligned CLI verbs are the clean model. 3b does NOT change code (except tiny fixups if a verb misbehaves during curation).
+- **The clean model, in one breath:** OOEVV ElementSet = reusable vocabulary of definitions; a `kefed-model` is a graph of `kefed-model-node`s (each typed by an OOEVV def via `kefed-node-type`, carrying `ooevv-variable`s via `kefed-node-variable`); flow edges `ooevv-process-input`/`-output` connect nodes; `ooevv-subject` marks the source; traversing from a `measurement` variable's node collects its indexing parameters = the **data signature**; `kefed-instance` + `ooevv-datum`/`ooevv-cell` hold the data table + `scilit-warrant`; claims/gaps (`scilit-claim`/`scilit-gap`) are span-anchored via `alh-derivation` with an AZ property; an investigation owns first-class `scilit-iteration`s each with 5 stage notes. Full design: `docs/superpowers/specs/2026-06-29-scilit-kefed-ooevv-reconfiguration-design.md`.
+
+## 1. Environment prereqs (verify, fix if needed)
+- **typedb-driver MUST be <3.11** in whatever venv runs DB ops. The main repo `/Users/gullyburns/skillful-alhazen/.venv` was found stale at 3.11.5 (which breaks EVERY DB op with `DriverOptions.__init__() got an unexpected keyword argument 'is_tls_enabled'`). Fixed via `uv sync --all-extras` (→ 3.8.0). If you see that error again: `cd /Users/gullyburns/skillful-alhazen && uv sync --all-extras`. The skill's own venv is fine (3.10.0). Verify: `.venv/bin/python -c "import importlib.metadata as m; print(m.version('typedb-driver'))"`.
+- TypeDB container `alhazen-typedb` running at `localhost:1729` (creds admin/password). Reconfigured-schema round-trip harness lives in the skill's `tests/`.
+
+## 2. Current LIVE state of `alh_deep_research` (verified 2026-06-30)
+This is the KEfED working DB (renamed from `alh_deep_research_ng` on Jun 29). It still runs the **OLD** schema.
+- **KEEP (raw layer):** 549 `scilit-paper`, 3 `scilit-corpus`, ~2569 `alh-artifact` (+ their fragments/representations).
+- **DELETE (old-schema curation layer):** ~849 `scilit-observation`, 418 `scilit-reported-claim`, 478 `kefed-model`, 387 `kefed-variable`, **1842 `kefed-instance`**, 1 `scilit-investigation`, plus fragments-as-curation / hinges / evidence / gaps / vocab-classifications specific to curation. (New types like `scilit-claim`/`scilit-gap`/`kefed-model-node` do NOT exist in the live DB yet.)
+- **The SIRT3 paper `scilit-paper-a5c569d48e76` is NOT in this DB** — it must be re-ingested (step 4). It is the Cell Reports 2013 study "SIRT3 Reverses Aging-Associated Degeneration in Hematopoietic Stem Cells" (Brown/Chen et al.). Resolve its DOI/PMID at ingest time via `scilit ingest` (OpenAlex/PubMed) — do NOT hardcode a guessed DOI.
+- **Latest safety snapshot:** `~/.alhazen/cache/typedb/alh_deep_research_export_20260630_232414.zip` (valid backup of the current DB; recover with `make db-import DB=alh_deep_research ZIP=<path>`). Take a FRESH one at step 3 anyway.
+
+## 3. Step 1 — Fresh snapshot + verify (SAFETY, do first)
+```
+cd /Users/gullyburns/skillful-alhazen
+make db-export DB=alh_deep_research           # -> ~/.alhazen/cache/typedb/alh_deep_research_export_<ts>.zip
+ls -lt ~/.alhazen/cache/typedb/alh_deep_research_export_*.zip | head -2
+```
+Confirm the new zip exists and is non-trivial (~1MB+). This is your rollback (`make db-import DB=alh_deep_research ZIP=<path>`).
+
+## 4. Step 2 — RECONCILE the schema in place (DESTRUCTIVE) — **test on a temp copy FIRST**
+Approach A (Gully's choice): keep the raw layer, wipe the curation layer, swap the curation schema to the branch's clean `schema.tql`.
+
+**MANDATORY: rehearse the whole reconcile on a temp copy before touching live.**
+1. Import the snapshot into a throwaway DB, e.g. `alh_dr_reconcile_test` (use `typedb_notebook.py import-db`/`make db-import` targeting a temp name, or the driver `databases` API). 
+2. Run steps (a)+(b)+(c) below against the temp DB; iterate the undefine until it loads clean and the raw layer is intact. ONLY when the temp rehearsal is clean, apply the identical sequence to live `alh_deep_research`.
+
+**(a) Delete curation-layer instances (keep raw).** Delete relations first, then entities, for every curation type. The KEEP set (do NOT delete): core `alh-*` (person/role/vocab/artifact/fragment/representation/fragmentation/collection/collection-membership/classification/derivation/aboutness/note-threading), `scilit-paper`(+`scilit-review`/`scilit-protocol`/`scilit-preprint`), `scilit-corpus`, `scilit-session`, `scilit-dataset`, `scilit-book`, the artifact subtypes (`scilit-jats-fulltext`/`scilit-pdf-fulltext`/`scilit-citation-record`/`scilit-supplementary`/`scilit-structured-data`), the fragment subtypes (`scilit-section`/`figure`/`table`/`paragraph`/`sentence`/`equation`/`reference`), `alh-vocabulary`/`alh-vocabulary-type`/`scilit-ontology-term`. **Everything else `scilit-*`/`kefed-*`/`ooevv-*` = curation → delete.** Enumerate the live curation types by introspecting the loaded schema (query subtypes of the curation bases) or diff the old `schema.tql` (main branch) vs the KEEP set. A `delete $x;` per type (relations before entities) with a variable bound each time (never a variable-free match).
+
+**(b) Undefine the old curation schema.** In TypeDB 3.x order: remove `owns`/`plays` first, then `sub`, then the type (see MEMORY.md "TypeDB 3.x Undefine Syntax"). This is the fiddly part — generate the undefine list from the live curation types (KEEP set excluded) and undefine leaf-first. If undefine of a specific type fights you, that's exactly why you rehearse on the temp DB.
+
+**(c) Load the reconfigured schema.** 
+```
+TYPEDB_DATABASE=alh_deep_research uv run --project local_skills/alhazen-core \
+  python local_skills/alhazen-core/alhazen_core.py load-schema \
+  /Users/gullyburns/Documents/GitHub/alhazen-skill-deep-research/skills/scientific-literature/schema.tql
+```
+Expect `{"success": true, ..., "schema": "loaded"}`, no `[DEX*]`/`[SYR*]`. Then sanity-check: `match $p isa scilit-paper; ... count` still 549; `match $n isa kefed-model-node;` resolves (new type present); `scilit-claim`/`kefed-node-type`/`kefed-node-variable` resolve.
+
+> If the in-place undefine proves intractable even on the temp copy, fall back is Approach B (fresh DB from `schema.tql` + re-import ONLY the raw layer via `src/skillful_alhazen/utils/subgraph_migrator.py copy --prefix scilit-paper/scilit-corpus ... --also-types <raw refs>`). Flag to Gully before switching approaches.
+
+## 5. Step 3 — Re-ingest the SIRT3 paper
+```
+cd <skill dir>
+uv run python scientific_literature.py ingest --doi "<resolve via search>"   # SIRT3 HSC-aging, Cell Reports 2013
+# or:  ... ingest --pmid "<pmid>"
+```
+Confirm a `scilit-paper` now exists for it; note its id (it will be deterministic per `paper_identity`, NOT the old `scilit-paper-a5c569d48e76`). Optionally `fetch-pdf` for full text so claims can span-anchor to real fragments.
+
+## 6. Step 4 — Re-curate SIRT3 on the clean model (via CLI verbs)
+**Content source:** the OLD seed captured the full SIRT3 curation. Recover it read-only for the content (fragments, 5 experiments, observations, claims):
+```
+git -C /Users/gullyburns/Documents/GitHub/alhazen-skill-deep-research show \
+  0d33677~1:skills/scientific-literature/prototypes/seed_sirt3_kqed.py
+```
+Re-express that content through the NEW verbs (get exact args via `uv run python scientific_literature.py <verb> --help`; cross-check the ledger + USAGE.md):
+1. **Investigation + iteration:** `create-investigation --type ... --name "Hallmarks of aging (KQED) — SIRT3"` (seeds iteration 1); `record-phase --iteration 1 --phase discovery/ingest/...`.
+2. **Per-paper sensemaking bundle:** `create-bundle --investigation <id> --paper <sirt3-paper-id> --iteration 1`.
+3. **KEfED experiments as node graphs** (5 of them: expression-profiling, loss-of-function [WT vs SIRT3-KO], gain-of-function [lentiviral SIRT3 rescue], + the others in the seed): for each — `add-experiment` (kefed-model + element-set + bundle link); `add-entity-node --subject` for the study subject (HSC/mouse) with parameter variables (genotype WT|KO, age young|old, SIRT3-level control|overexpressed — ground to EFO); `add-process` for each assay (qPCR, western, flow cytometry, competitive transplantation, colony-forming); `link-nodes` subject→assay (role input); `add-variable --node <assay> --role measurement` for the readouts (expression, enzymatic activity, reconstitution %, ROS); `bind-parameter` where needed. Verify each with `show-data-signature --model <id>` (each measurement should index its condition parameters).
+4. **Observations** (the seed's O1AC/O3E/O3G/O3IJ/O4DF…): `add-observation --bundle <id> --statement "..." --knowledge-level association|assertion --bio-scale molecular|tissue --source-label OF1A+C`. Pass the seed's code through `--source-label` (it becomes the note `name`; statement stays in `content`) — **rewrite legacy bare-figure codes to the explicit form** (`O4DF` → `OF4DF`) and use the non-figure forms where the evidence isn't a main figure (`OSF3B` supplemental, `OT2` table, `OE5` figure-less experiment, `OX` text-only). Grammar: `skills/scientific-literature/docs/observation-source-labeling.md`. Then span-anchor to the paper's fragment quotes (F5/F8/F10/F12… — via `kqed.add_fragment` + `ground_note`/`alh-derivation`).
+5. **Claims/gaps:** `add-reported-claim` (now `scilit-claim`, AZ role) span-anchored to fragments; `add-reported-gap` for "future studies will determine the effect of SIRT3 on lifespan" (F13); hinges/mechanisms as in the seed.
+6. **Instance + data table** where the seed had data rows: `instantiate-template`/instance + `add-datum --cells` (validated against the model's variables).
+
+## 7. Step 5 — Verify
+- `show-investigation`, `show-bundle`, `show-data-signature`, `show-instance` round-trip the SIRT3 record on the clean model.
+- Counts: raw layer intact (549 papers); new curation types populated (`scilit-claim`, `kefed-model-node`, `kefed-node-variable`, `kefed-instance`); no `[INF2]` on any read verb.
+- Full test suite still 67/67 (schema unchanged by data ops).
+- Then re-snapshot: `make db-export DB=alh_deep_research`.
+
+## 8. After SIRT3
+Gully wants the rest of the previously-curated data reingested from scratch too — SIRT3 is the first exemplar / proof of the workflow. Once SIRT3 is clean, generalize the recipe (it's the same verb sequence per study) and work through the other studies. The whole PR (Parts 1–3b) can then move from draft → ready.
+
+## Safety rules (non-negotiable)
+- Snapshot before ANY destructive step; verify the zip; know the `make db-import` recovery.
+- Rehearse the reconcile on a TEMP copy before live.
+- Never a variable-free schema match (crashes TypeDB 3.8).
+- Commit only intended files; the code side is frozen — 3b is data + at most tiny verb fixups (push those upstream on the branch, keep tests green).
+- External skill: all code edits are in the upstream repo on `feat/scilit-schema-reconfiguration`.

--- a/docs/superpowers/specs/2026-06-29-scilit-kefed-ooevv-reconfiguration-design.md
+++ b/docs/superpowers/specs/2026-06-29-scilit-kefed-ooevv-reconfiguration-design.md
@@ -1,0 +1,251 @@
+# Design Spec — Reconfigure scientific-literature: clean OOEVV / KEfED / rhetorical model + investigation-first dashboard
+
+**Date:** 2026-06-29
+**Status:** approved design (Sub-project 1 ready for implementation planning)
+**Skill:** `scientific-literature` — upstream `sciknow-io/alhazen-skill-deep-research`,
+working dir `~/Documents/GitHub/alhazen-skill-deep-research/skills/scientific-literature/`,
+DB `alh_deep_research`.
+
+---
+
+## 1. Context & motivation
+
+The `scientific-literature` skill is mature but has a muddled epistemic core and a jumbled UI:
+
+- **The OOEVV/KEfED schema is unclear where it matters most.** `kefed-model` is annotated *"the OOEVV
+  ElementSet = ONE experiment"* (schema.tql:842), fusing three distinct ideas — the *class vocabulary*,
+  the *one-experiment bigraph*, and *one experiment*. A prototype layer (`kefed-model` /
+  `kefed-variable` / `kefed-observed-via`) coexists with the live template/instance layer, and an
+  observation attaches to experimental structure two different ways (`kefed-observed-via` vs
+  `ooevv-datum-observation`).
+- **The dashboard is "super jumbled."** ~10 pages, weak IA, orphan pages (kqed, acquisition), layout
+  primitives scattered across feature files, duplicated header markup, raw-JSON/script dumps, and —
+  critically — **no access to the original full text** of papers and **no clean traversal** from a claim
+  to the text and data that ground it.
+
+**Decision: reconfigure, not add.** We author the clean target model from first principles (the KEfED /
+OOEVV semantics below) and reconfigure the existing scilit work onto it — *replacing* the muddled types
+rather than layering beside them. **Delete + reingest is acceptable** (no id-preserving migration). The
+dashboard is then rebuilt against the clean model.
+
+**Intended outcome:** an epistemically precise, legible knowledge model whose dashboard gives a
+researcher direct access to (a) the curation data, (b) the original paper text, and (c) a traversable
+path from any claim → its argumentative role → the verbatim text → the experimental data and warrant
+behind it.
+
+---
+
+## 2. The reconfigured conceptual model
+
+### 2A. OOEVV vocabulary layer — building blocks (ontological commitment)
+
+An **OOEVV ElementSet** exhaustively defines the reusable vocabulary for a *class* of experiments
+("this is how we describe RNASeq experiments"). It is a **first-class object**, distinct from any one
+experiment, template, or instance. Its elements:
+
+| Element | Kinds |
+|---|---|
+| **Entity** | `material-entity` (obo:BFO_0000040) OR `information-content-entity` (obo:IAO_0000030) — the latter subsumes datasets |
+| **Process** | `assay` \| `material-processing` \| `data-transformation` |
+| **Variable** (an ICE that takes values) | role ∈ { `constant`, `parameter`, `measurement` } |
+| **Measurement scale** (value mapping for a variable) | `nominal` \| `binary` \| `ordinal` \| `numeric` \| `file` \| `composite` |
+
+> **Core fix:** the ElementSet (class vocabulary) becomes its own type (`ooevv-element-set`), **un-fused**
+> from `kefed-model`.
+
+### 2B. KEfED model layer — the bigraph
+
+A **KEfED model** is a **bipartite graph of entities ↔ processes**, built from exactly one ElementSet:
+
+- entities are the **inputs and outputs** of processes;
+- **both entities and processes carry variables as parameters** — the schema currently binds parameters
+  only at processes; entity-borne parameters are a **missing edge** to add;
+- any ICE in the graph is a **measurement** (assay output) or a **derived** ICE (transformation output).
+
+**Subject-first spine.** A model reads top-to-bottom: **subject material → manipulations
+(`material-processing` binding treatment params) → assays → measured variables → data.** The subject is
+the **source node** (no incoming output edge), marked with an **explicit role** so the renderer always
+knows where the protocol begins.
+
+**Template = a model with no variables instantiated.** Template and a filled-in experiment are the *same
+object type in two states* (zero values bound = template; values bound = a described experiment).
+Consequently the separate `kefed-slot` type **collapses into uninstantiated entity-valued parameter
+variables** — a "slot kind" (`gene | chemical | cell-type`) is just the entity-type that variable's
+value targets, and "filling a slot" is "instantiating that variable."
+
+**Indexing is the point of KEfED:** which **parameters** index the **measurements** and downstream data.
+
+- A **raw measurement's index set** is **derived by upstream traversal** of the bigraph (the
+  parameter-bearing entities/processes on the paths producing it). Stored only as the graph + values;
+  the index is *computed*.
+- **Derived data breaks simple traversal** — a computation combines parameters non-trivially.
+  **Decision: full computational provenance.** Every `data-transformation` is modeled as a **typed
+  function over (input data + parameters) → output** that **declares explicit parameter-mapping rules**
+  for how its input parameters propagate into output parameters (the transformation can change or destroy
+  parameters as a hidden part of the computation, so this must be curated, not inferred). Rule kinds
+  include:
+  - **passthrough** — an input parameter carries to the output unchanged;
+  - **aggregate-collapse / destroy** — a set-reducing op (e.g. a **mean over replicates**) **consumes
+    and destroys** the index parameter of the measurements it folds together, so the output is no longer
+    indexed by it;
+  - **combine** — two (or more) parameters fold into a single derived index (e.g. a fold-change yielding
+    a *contrast* of conditions; a ratio collapsing two contexts);
+  - **derive** — the computation introduces a *new* output parameter not present on any input.
+
+  A derived datum's **index set is computed by applying these rules** to its inputs' index sets — so
+  indexing **composes through the workflow** and stays machine-derivable end to end. Many mapping rules
+  are possible per computation; the rule set is part of the curated transformation.
+
+**Data table + warrant are persisted curation.** Instantiating variables produces recorded rows (each
+row = one measurement context); the table **and** the derived **warrant** (what each measurement
+licenses, following from its index set) are preserved as curation artifacts — today's
+instance/datum/cell layer, reconfigured onto the clean model.
+
+### 2C. Rhetorical layer — span-anchored claims
+
+- Every **claim / observation is anchored to one or more verbatim text fragments** (char offsets into
+  the cached full text), so the UI can traverse a claim → the exact supporting sentence(s).
+- The **AZ (argumentative zone)** rides as a **property** of each claim.
+- **Hinges** (Teufel CFC, claim↔claim / claim↔paper) and **gaps** are **typed relations** over the
+  anchored claims.
+
+**Claim ↔ evidence = linked but unconstrained.** A traversable provenance chain, *not* a gate:
+
+```
+claim → supporting observation(s) → measurement(s) → index set → data row → verbatim source text
+```
+
+The KEfED **warrant is shown beside the claim** (so over/under-claiming is visible) but nothing forces
+the claim's asserted strength to match it — the human judges fit.
+
+### 2D. Investigation / iteration layer — the dashboard backbone
+
+- An **investigation** is the top-level, goal-driven unit.
+- It owns an **ordered sequence of first-class iteration objects**. Each **iteration** is a
+  self-contained round of effort with **its own corpus configuration** (paper set + selection criteria
+  for that round) and **its own five stage notes**: `discovery → ingest → sensemaking → analysis →
+  report`.
+- The dashboard sidebar shows the five stages of the **selected iteration**; an iteration switcher picks
+  the round.
+
+---
+
+## 3. The dashboard (investigation-first IA) — *Sub-project 2, designed here for coherence*
+
+1. **Landing = list of investigations** (not corpora).
+2. **Investigation page** — iteration switcher + left sidebar of the 5 stages for the selected iteration:
+   - **A · Discovery** — the criteria/queries used to build the corpora in this iteration.
+   - **B · Ingestion** — paged list of papers with ingestion status (`missing` / `abstract` /
+     `full-text` / `full-text + supplements`) and links to view each paper's **artifacts and fragments**,
+     including the original cached full text.
+   - **C · Sensemaking** — list of papers; click-through to the notes for each paper, then deeper
+     click-through into the **KQED / KEfED / OOEVV** extractions for that paper.
+   - **D · Analysis** — workflows + visualizations + analysis for this iteration (faceting pipelines, etc.).
+   - **E · Reports** — audience-facing writeups.
+3. **OOEVV browser** — a browsable + searchable list of **typed entities formatted per the OOEVV paper**,
+   showing the properties and definitions of each term.
+4. **KEfED template view** — the **complete parameterized experimental protocol**: subject →
+   manipulations on the animal/sample → assays → data. We don't pre-specify many templates; the view
+   renders whatever exists.
+5. **Claim ↔ text ↔ data traversal** — claims always grounded in text with links back to supporting
+   verbatim spans, displayed together with the rhetorical (AZ) constructs and the epistemic KEfED data
+   tables / observations.
+
+**Build mechanics:** source-of-truth is `dashboard/{components,lib.ts,pages,routes}` in the upstream
+skill repo; `make build-dashboard` copies the 4 slots into `dashboard/src/`. NEVER edit `dashboard/src/`
+directly. External-skill changes are pushed upstream.
+
+---
+
+## 4. Decomposition & sequencing — schema-first
+
+Two sub-projects, foundation-up. **Sub-project 1 is built fully first**; the dashboard is a later cycle
+(the dashboard can't surface a clean model that doesn't exist yet).
+
+### Sub-project 1 — Reconfigured schema + teardown + CLI  *(the active work)*
+
+**Critical files (all upstream):**
+- `schema.tql` — reconfigure the OOEVV/KEfED/KQED/investigation blocks (~lines 422–963).
+- `kqed.py` — reconfigure authoring verbs (`add_kefed_model`, `add_observation`, grounding, etc.).
+- `scientific_literature.py` — reconfigure the KEfED/OOEVV/investigation authoring `cmd_*` and read
+  `_load_*` paths onto the clean model.
+- `migrations/` — a **teardown script** deleting the reconfigured curation-layer instances so they can
+  be re-curated. No id-preserving copy.
+- `tests/` — update/extend support-module tests.
+
+**Target type changes (concept → schema):**
+- **New `ooevv-element-set`** grouping its entities/processes/variables/scales — un-fused from `kefed-model`.
+- **Entities** split `material-entity` (obo:BFO_0000040) vs `information-content-entity`
+  (obo:IAO_0000030); ICEs typed *measurement* vs *derived*.
+- **Variables** keep `constant|parameter|measurement`; **add entity-borne parameter binding**.
+- **Processes** `assay|material-processing|data-transformation`; **data-transformation carries typed
+  parameter-mapping rules** (`passthrough` / `aggregate-collapse-destroy` / `combine` / `derive`) over
+  (input data + params) → output, so the derived-datum index composes through the workflow (full
+  computational provenance).
+- **`kefed-model` = the bigraph only** (built from one element-set); **subject role** marks the source node.
+- **Template = uninstantiated model**; **retire `kefed-slot`**; reconcile `kefed-template`/`kefed-instance`
+  into the single model-with-state + persisted data-table/warrant.
+- **Retire `kefed-observed-via`** (dual observation link); observation↔data bridges via the datum link only.
+- **Rhetorical:** span-anchored claims/observations; AZ as property; typed hinges/gaps; linked-unconstrained
+  claim→evidence chain.
+- **Investigation/iteration:** first-class **iteration** object; investigation owns ordered iterations;
+  each iteration owns corpus-config + 5 stage notes — reconfigure current phase-threading.
+
+**Data approach — delete + reingest (approved).** No id-preserving migration. Take a `make db-export`
+snapshot first (repo rule), then **drop the reconfigured curation layer** (KEfED / OOEVV / rhetorical /
+investigation instances) and **re-curate** it into the clean model. **Keep the raw ingested layer** —
+papers, corpora, cached full-text artifacts/fragments (clean and costly to re-fetch); scope is widenable.
+Recovery via `make db-import` from the snapshot.
+
+### Sub-project 2 — Investigation-first dashboard rewrite  *(later cycle)*
+
+The IA in §3, built against the clean model. Separate spec → plan → execution.
+
+---
+
+## 5. Verification (Sub-project 1)
+
+- `make db-export` snapshot taken and verified first; schema reloads cleanly; papers/corpora/full-text
+  layer intact afterward.
+- CLI round-trips the clean model (author → read-back) by **re-curating a worked example** (e.g. the
+  hallmarks/SIRT3 record) into the new model end-to-end: element-set, bigraph, instantiated data table +
+  warrant, span-anchored claims, iteration/stage structure.
+- Support-module + CLI tests pass.
+
+---
+
+## 6. Open / deferred
+
+- **OOEVV vocabulary grounding — default: YES (reversible).** Ground the full element vocabulary to
+  upper ontologies, consistent with the entity split: `process` → `obo:BFO_0000015`; `assay` →
+  `obo:OBI_0000070`; `material-processing` → `obo:OBI_0000094`; `data-transformation` →
+  `obo:OBI_0200000`; `measurement` → `obo:IAO_0000109`; entities per §2A. **Variable definitions ground
+  to EFO** (Experimental Factor Ontology) factor terms — the variable structurally subsumes under
+  `obo:IAO_0000030` (ICE), but its grounding target is an EFO factor (consistent with the existing
+  `kefed-efo-label` intent). **Measurement scales keep OOEVV's own taxonomy** (no crisp BFO/IAO parent).
+  Each element type carries its CURIE via the existing `scilit-curie` slot.
+- Exact AZ zone inventory and CFC hinge-type vocabulary (curated as `alh-vocabulary` terms; finalize
+  during implementation).
+- OOEVV-browser term-card layout fidelity to the OOEVV paper (Sub-project 2).
+- Whether the "keep raw ingested layer" boundary widens to re-fetch any papers.
+
+---
+
+## 7. Addendum (2026-07-01) — first-class value-specifications + grounding policy (implemented)
+
+Refines the OOEVV vocabulary layer per Gully:
+
+- **Value-specifications are first-class + shared.** A `variable = a shared QUALITY (semantics) + a shared
+  VALUE-SPECIFICATION (the value space + method)`. A **value-specification IS an `ooevv-scale`** (nominal /
+  binary / ordinal / numeric / file / composite), now **named, reusable and grounded-capable** (it already
+  subs `ooevv-element`). NEW relation **`ooevv-quality-scale`** lets a quality **enumerate its canonical
+  value-specs**, so the *same* quality can be measured *different* ways (e.g. `age` → `{ordinal
+  young<mature<old}` + `{numeric days}`). A variable **references** a shared value-spec (one scale, many
+  variables) via `ooevv-has-scale`. Verbs: `ensure-value-spec`, `add-variable --value-spec`,
+  `list-value-specs`; grounding-owns moved up to `ooevv-element`.
+- **Grounding is correctness-gated (not fabricated).** Attach a `scilit-curie` **only** when a verified,
+  definition-matching ontology term exists; otherwise mark `grounding-state "ungrounded"` and keep the
+  precise local definition. Never approximate or guess a curie.
+- **Curation is vocabulary-first, recognize→reuse→extend.** Qualities + value-specs are the DB-grown source
+  of truth; curation lists and reuses them, extending (and grounding, where verifiable) as needed. See
+  `SKILL.md` §"KEfED Model Authoring" for the operational method.

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/01_investigation.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/01_investigation.yaml
@@ -1,0 +1,8 @@
+name: 01_investigation
+description: 01 investigation
+depends_on: []
+idempotent: true
+source_match: 'match $i isa scilit-investigation, has id "scinv-3e0aa419866c", has scilit-investigation-status $st, has scilit-investigation-question $q, has scilit-investigation-type $ty, has name $nm, has content $bd; fetch { "f_id": $i.id, "f_name": $nm, "f_content": $bd, "f_status": $st, "f_question": $q, "f_type": $ty };'
+target_insert: insert $i isa scilit-investigation, has id $f_id, has name $f_name, has content $f_content, has scilit-investigation-status $f_status, has scilit-investigation-question $f_question, has scilit-investigation-type $f_type, has scilit-iteration-number 1, has created-at 2026-06-26T12:00:00;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/02_papers_base.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/02_papers_base.yaml
@@ -1,0 +1,8 @@
+name: 02_papers_base
+description: 02 papers base
+depends_on: []
+idempotent: true
+source_match: 'match $cc isa scilit-corpus, has id "collection-b329eae9911b"; (collection: $cc, member: $p) isa alh-collection-membership; $p isa scilit-paper, has name $nm; fetch { "f_id": $p.id, "f_name": $nm };'
+target_insert: insert $p isa scilit-paper, has id $f_id, has name $f_name, has created-at 2026-06-26T12:00:00;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/02b_papers_citing.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/02b_papers_citing.yaml
@@ -1,0 +1,8 @@
+name: 02b_papers_citing
+description: 02b papers citing
+depends_on: []
+idempotent: true
+source_match: 'match $i isa scilit-investigation, has id "scinv-3e0aa419866c"; (parent-note: $i, child-note: $im) isa alh-note-threading; $im isa scilit-citation-impact; (note: $im, subject: $p) isa alh-aboutness; $p isa scilit-paper, has name $nm; fetch { "f_id": $p.id, "f_name": $nm };'
+target_insert: insert $p isa scilit-paper, has id $f_id, has name $f_name, has created-at 2026-06-26T12:00:00;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/02c_papers_hinge.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/02c_papers_hinge.yaml
@@ -1,0 +1,8 @@
+name: 02c_papers_hinge
+description: 02c papers hinge
+depends_on: []
+idempotent: true
+source_match: 'match $cc isa scilit-corpus, has id "collection-b329eae9911b"; $kp isa scilit-paper; (collection: $cc, member: $kp) isa alh-collection-membership; $k isa scilit-investigation, has scilit-investigation-type "deep-dive"; not { $k has id "scinv-3e0aa419866c"; }; (note: $k, subject: $kp) isa alh-aboutness;  (parent-note: $k, child-note: $cl) isa alh-note-threading; $cl isa scilit-claim; (hinging-claim: $cl, hinged-to: $tt) isa scilit-hinge; $tt isa scilit-paper, has name $nm; fetch { "f_id": $tt.id, "f_name": $nm };'
+target_insert: insert $p isa scilit-paper, has id $f_id, has name $f_name, has created-at 2026-06-26T12:00:00;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/03_papers_doi.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/03_papers_doi.yaml
@@ -1,0 +1,9 @@
+name: 03_papers_doi
+description: 03 papers doi
+depends_on:
+- 02_papers_base
+idempotent: true
+source_match: 'match $cc isa scilit-corpus, has id "collection-b329eae9911b"; (collection: $cc, member: $p) isa alh-collection-membership; $p isa scilit-paper, has scilit-doi $d; fetch { "f_id": $p.id, "f_doi": $d };'
+target_insert: match $p isa scilit-paper, has id $f_id; insert $p has scilit-doi $f_doi;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/04_papers_year.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/04_papers_year.yaml
@@ -1,0 +1,9 @@
+name: 04_papers_year
+description: 04 papers year
+depends_on:
+- 02_papers_base
+idempotent: true
+source_match: 'match $cc isa scilit-corpus, has id "collection-b329eae9911b"; (collection: $cc, member: $p) isa alh-collection-membership; $p isa scilit-paper, has scilit-publication-year $y; fetch { "f_id": $p.id, "f_year": $y };'
+target_insert: match $p isa scilit-paper, has id $f_id; insert $p has scilit-publication-year $f_year;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/05_corpus.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/05_corpus.yaml
@@ -1,0 +1,8 @@
+name: 05_corpus
+description: 05 corpus
+depends_on: []
+idempotent: true
+source_match: 'match $c isa scilit-corpus, has id "collection-b329eae9911b", has name $nm; fetch { "f_id": $c.id, "f_name": $nm };'
+target_insert: insert $c isa scilit-corpus, has id $f_id, has name $f_name, has created-at 2026-06-26T12:00:00;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/06_corpus_membership.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/06_corpus_membership.yaml
@@ -1,0 +1,11 @@
+name: 06_corpus_membership
+description: 06 corpus membership
+depends_on:
+- 05_corpus
+- 02_papers_base
+idempotent: true
+source_match: 'match $c isa scilit-corpus, has id "collection-b329eae9911b"; (collection: $c, member: $p) isa alh-collection-membership; $p isa scilit-paper; fetch { "f_cid": $c.id, "f_pid": $p.id };'
+target_insert: 'match $c isa scilit-corpus, has id $f_cid; $p isa scilit-paper, has id $f_pid; insert (collection: $c, member: $p) isa alh-collection-membership;'
+skolem_keys:
+- f_cid
+- f_pid

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/07_inv_scope.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/07_inv_scope.yaml
@@ -1,0 +1,11 @@
+name: 07_inv_scope
+description: 07 inv scope
+depends_on:
+- 01_investigation
+- 05_corpus
+idempotent: true
+source_match: 'match $i isa scilit-investigation, has id "scinv-3e0aa419866c"; (note: $i, subject: $c) isa alh-aboutness; $c isa scilit-corpus, has id "collection-b329eae9911b"; fetch { "f_iid": $i.id, "f_cid": $c.id };'
+target_insert: 'match $i isa scilit-investigation, has id $f_iid; $c isa scilit-corpus, has id $f_cid; insert (investigation: $i, corpus: $c) isa scilit-investigation-scope;'
+skolem_keys:
+- f_iid
+- f_cid

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/08_inv_focus.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/08_inv_focus.yaml
@@ -1,0 +1,11 @@
+name: 08_inv_focus
+description: 08 inv focus
+depends_on:
+- 01_investigation
+- 02_papers_base
+idempotent: true
+source_match: 'match $i isa scilit-investigation, has id "scinv-3e0aa419866c"; (note: $i, subject: $p) isa alh-aboutness; $p isa scilit-paper; fetch { "f_iid": $i.id, "f_pid": $p.id };'
+target_insert: 'match $i isa scilit-investigation, has id $f_iid; $p isa scilit-paper, has id $f_pid; insert (investigation: $i, focal-paper: $p) isa scilit-investigation-focus;'
+skolem_keys:
+- f_iid
+- f_pid

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/09_phases_existing.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/09_phases_existing.yaml
@@ -1,0 +1,8 @@
+name: 09_phases_existing
+description: 09 phases existing
+depends_on: []
+idempotent: true
+source_match: 'match $i isa scilit-investigation, has id "scinv-3e0aa419866c"; (parent-note: $i, child-note: $ph) isa alh-note-threading; $ph isa scilit-investigation-phase, has scilit-phase $phase, has name $nm, has content $c; fetch { "f_id": $ph.id, "f_phase": $phase, "f_name": $nm, "f_content": $c };'
+target_insert: insert $ph isa scilit-investigation-phase, has id $f_id, has scilit-phase $f_phase, has name $f_name, has content $f_content, has scilit-iteration-number 1, has created-at 2026-06-26T12:00:00;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/10_phasing_existing.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/10_phasing_existing.yaml
@@ -1,0 +1,11 @@
+name: 10_phasing_existing
+description: 10 phasing existing
+depends_on:
+- 01_investigation
+- 09_phases_existing
+idempotent: true
+source_match: 'match $i isa scilit-investigation, has id "scinv-3e0aa419866c"; (parent-note: $i, child-note: $ph) isa alh-note-threading; $ph isa scilit-investigation-phase; fetch { "f_iid": $i.id, "f_pid": $ph.id };'
+target_insert: 'match $i isa scilit-investigation, has id $f_iid; $ph isa scilit-investigation-phase, has id $f_pid; insert (investigation: $i, phase: $ph) isa scilit-investigation-phasing;'
+skolem_keys:
+- f_iid
+- f_pid

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/11_phase_sensemaking.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/11_phase_sensemaking.yaml
@@ -1,0 +1,8 @@
+name: 11_phase_sensemaking
+description: 11 phase sensemaking
+depends_on: []
+idempotent: true
+source_match: 'match $i isa scilit-investigation, has id "scinv-3e0aa419866c"; fetch { "f_id": $i.id };'
+target_insert: insert $ph isa scilit-investigation-phase, has id "scphase-hallmarks-sensemaking", has scilit-phase "sensemaking", has name "Sensemaking phase", has scilit-iteration-number 1, has created-at 2026-06-26T12:00:00;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/12_phasing_sensemaking.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/12_phasing_sensemaking.yaml
@@ -1,0 +1,10 @@
+name: 12_phasing_sensemaking
+description: 12 phasing sensemaking
+depends_on:
+- 01_investigation
+- 11_phase_sensemaking
+idempotent: true
+source_match: 'match $i isa scilit-investigation, has id "scinv-3e0aa419866c"; fetch { "f_id": $i.id };'
+target_insert: 'match $i isa scilit-investigation, has id $f_id; $ph isa scilit-investigation-phase, has id "scphase-hallmarks-sensemaking"; insert (investigation: $i, phase: $ph) isa scilit-investigation-phasing;'
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/13_synthesized_claims.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/13_synthesized_claims.yaml
@@ -1,0 +1,8 @@
+name: 13_synthesized_claims
+description: 13 synthesized claims
+depends_on: []
+idempotent: true
+source_match: 'match $i isa scilit-investigation, has id "scinv-3e0aa419866c"; (parent-note: $i, child-note: $cl) isa alh-note-threading; $cl isa scilit-claim, has scilit-claim-statement $s, has scilit-claim-type $t; fetch { "f_id": $cl.id, "f_stmt": $s, "f_type": $t };'
+target_insert: insert $cl isa scilit-synthesized-claim, has id $f_id, has scilit-claim-statement $f_stmt, has scilit-claim-type $f_type, has created-at 2026-06-26T12:00:00;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/14_inv_synthesized_claim.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/14_inv_synthesized_claim.yaml
@@ -1,0 +1,11 @@
+name: 14_inv_synthesized_claim
+description: 14 inv synthesized claim
+depends_on:
+- 01_investigation
+- 13_synthesized_claims
+idempotent: true
+source_match: 'match $i isa scilit-investigation, has id "scinv-3e0aa419866c"; (parent-note: $i, child-note: $cl) isa alh-note-threading; $cl isa scilit-claim; fetch { "f_iid": $i.id, "f_cid": $cl.id };'
+target_insert: 'match $i isa scilit-investigation, has id $f_iid; $cl isa scilit-synthesized-claim, has id $f_cid; insert (investigation: $i, synthesized-claim: $cl) isa scilit-investigation-synthesized-claim;'
+skolem_keys:
+- f_iid
+- f_cid

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/15_evidence_base.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/15_evidence_base.yaml
@@ -1,0 +1,8 @@
+name: 15_evidence_base
+description: 15 evidence base
+depends_on: []
+idempotent: true
+source_match: 'match $i isa scilit-investigation, has id "scinv-3e0aa419866c"; (parent-note: $i, child-note: $cl) isa alh-note-threading; $cl isa scilit-claim; (parent-note: $cl, child-note: $e) isa alh-note-threading; $e isa scilit-evidence;  fetch { "f_id": $e.id };'
+target_insert: insert $e isa scilit-evidence, has id $f_id, has confidence 0.5, has created-at 2026-06-26T12:00:00;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/16_evidence_content.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/16_evidence_content.yaml
@@ -1,0 +1,9 @@
+name: 16_evidence_content
+description: 16 evidence content
+depends_on:
+- 15_evidence_base
+idempotent: true
+source_match: 'match $i isa scilit-investigation, has id "scinv-3e0aa419866c"; (parent-note: $i, child-note: $cl) isa alh-note-threading; $cl isa scilit-claim; (parent-note: $cl, child-note: $e) isa alh-note-threading; $e isa scilit-evidence;  $e has scilit-data-summary $ds; fetch { "f_id": $e.id, "f_content": $ds };'
+target_insert: match $e isa scilit-evidence, has id $f_id; insert $e has content $f_content;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/17_evidence_type.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/17_evidence_type.yaml
@@ -1,0 +1,9 @@
+name: 17_evidence_type
+description: 17 evidence type
+depends_on:
+- 15_evidence_base
+idempotent: true
+source_match: 'match $i isa scilit-investigation, has id "scinv-3e0aa419866c"; (parent-note: $i, child-note: $cl) isa alh-note-threading; $cl isa scilit-claim; (parent-note: $cl, child-note: $e) isa alh-note-threading; $e isa scilit-evidence;  $e has scilit-evidence-type $et; fetch { "f_id": $e.id, "f_etype": $et };'
+target_insert: match $e isa scilit-evidence, has id $f_id; insert $e has scilit-evidence-type $f_etype;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/18_claim_evidence.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/18_claim_evidence.yaml
@@ -1,0 +1,11 @@
+name: 18_claim_evidence
+description: 18 claim evidence
+depends_on:
+- 13_synthesized_claims
+- 15_evidence_base
+idempotent: true
+source_match: 'match $i isa scilit-investigation, has id "scinv-3e0aa419866c"; (parent-note: $i, child-note: $cl) isa alh-note-threading; $cl isa scilit-claim; (parent-note: $cl, child-note: $e) isa alh-note-threading; $e isa scilit-evidence;  fetch { "f_cid": $cl.id, "f_eid": $e.id };'
+target_insert: 'match $cl isa scilit-synthesized-claim, has id $f_cid; $e isa scilit-evidence, has id $f_eid; insert (synthesized-claim: $cl, evidence: $e) isa scilit-claim-evidence;'
+skolem_keys:
+- f_cid
+- f_eid

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/19_citation_impacts.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/19_citation_impacts.yaml
@@ -1,0 +1,8 @@
+name: 19_citation_impacts
+description: 19 citation impacts
+depends_on: []
+idempotent: true
+source_match: 'match $i isa scilit-investigation, has id "scinv-3e0aa419866c"; (parent-note: $i, child-note: $im) isa alh-note-threading; $im isa scilit-citation-impact, has scilit-impact-type $it, has scilit-impact-summary $is; fetch { "f_id": $im.id, "f_itype": $it, "f_isum": $is };'
+target_insert: insert $im isa scilit-citation-impact, has id $f_id, has scilit-impact-type $f_itype, has scilit-impact-summary $f_isum, has created-at 2026-06-26T12:00:00;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/20_inv_impact.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/20_inv_impact.yaml
@@ -1,0 +1,11 @@
+name: 20_inv_impact
+description: 20 inv impact
+depends_on:
+- 01_investigation
+- 19_citation_impacts
+idempotent: true
+source_match: 'match $i isa scilit-investigation, has id "scinv-3e0aa419866c"; (parent-note: $i, child-note: $im) isa alh-note-threading; $im isa scilit-citation-impact; fetch { "f_iid": $i.id, "f_mid": $im.id };'
+target_insert: 'match $i isa scilit-investigation, has id $f_iid; $im isa scilit-citation-impact, has id $f_mid; insert (investigation: $i, impact: $im) isa scilit-investigation-impact;'
+skolem_keys:
+- f_iid
+- f_mid

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/21_impact_citation.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/21_impact_citation.yaml
@@ -1,0 +1,11 @@
+name: 21_impact_citation
+description: 21 impact citation
+depends_on:
+- 19_citation_impacts
+- 02b_papers_citing
+idempotent: true
+source_match: 'match $i isa scilit-investigation, has id "scinv-3e0aa419866c"; (parent-note: $i, child-note: $im) isa alh-note-threading; $im isa scilit-citation-impact; (note: $im, subject: $p) isa alh-aboutness; $p isa scilit-paper; fetch { "f_mid": $im.id, "f_pid": $p.id };'
+target_insert: 'match $im isa scilit-citation-impact, has id $f_mid; $p isa scilit-paper, has id $f_pid; insert (impact: $im, citing-paper: $p) isa scilit-impact-citation;'
+skolem_keys:
+- f_mid
+- f_pid

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/22_grounding_policy.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/22_grounding_policy.yaml
@@ -1,0 +1,8 @@
+name: 22_grounding_policy
+description: 22 grounding policy
+depends_on: []
+idempotent: true
+source_match: 'match $i isa scilit-investigation, has id "scinv-3e0aa419866c"; (parent-note: $i, child-note: $pp) isa alh-note-threading; $pp isa scilit-grounding-policy, has content $c, has name $nm; fetch { "f_id": $pp.id, "f_content": $c, "f_name": $nm };'
+target_insert: insert $pp isa scilit-grounding-policy, has id $f_id, has content $f_content, has name $f_name, has created-at 2026-06-26T12:00:00;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/23_inv_grounding.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/23_inv_grounding.yaml
@@ -1,0 +1,11 @@
+name: 23_inv_grounding
+description: 23 inv grounding
+depends_on:
+- 01_investigation
+- 22_grounding_policy
+idempotent: true
+source_match: 'match $i isa scilit-investigation, has id "scinv-3e0aa419866c"; (parent-note: $i, child-note: $pp) isa alh-note-threading; $pp isa scilit-grounding-policy; fetch { "f_iid": $i.id, "f_pid": $pp.id };'
+target_insert: 'match $i isa scilit-investigation, has id $f_iid; $pp isa scilit-grounding-policy, has id $f_pid; insert (investigation: $i, policy: $pp) isa scilit-investigation-grounding;'
+skolem_keys:
+- f_iid
+- f_pid

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/24_bundles.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/24_bundles.yaml
@@ -1,0 +1,8 @@
+name: 24_bundles
+description: 24 bundles
+depends_on: []
+idempotent: true
+source_match: 'match $cc isa scilit-corpus, has id "collection-b329eae9911b"; $kp isa scilit-paper; (collection: $cc, member: $kp) isa alh-collection-membership; $k isa scilit-investigation, has scilit-investigation-type "deep-dive"; not { $k has id "scinv-3e0aa419866c"; }; (note: $k, subject: $kp) isa alh-aboutness;  $k has name $kn; fetch { "f_id": $k.id, "f_name": $kn };'
+target_insert: insert $b isa scilit-paper-sensemaking, has id $f_id, has name $f_name, has created-at 2026-06-26T12:00:00;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/25_bundle_paper.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/25_bundle_paper.yaml
@@ -1,0 +1,11 @@
+name: 25_bundle_paper
+description: 25 bundle paper
+depends_on:
+- 24_bundles
+- 02_papers_base
+idempotent: true
+source_match: 'match $cc isa scilit-corpus, has id "collection-b329eae9911b"; $kp isa scilit-paper; (collection: $cc, member: $kp) isa alh-collection-membership; $k isa scilit-investigation, has scilit-investigation-type "deep-dive"; not { $k has id "scinv-3e0aa419866c"; }; (note: $k, subject: $kp) isa alh-aboutness;  fetch { "f_kid": $k.id, "f_pid": $kp.id };'
+target_insert: 'match $b isa scilit-paper-sensemaking, has id $f_kid; $p isa scilit-paper, has id $f_pid; insert (sensemaking: $b, paper: $p) isa scilit-sensemaking-paper;'
+skolem_keys:
+- f_kid
+- f_pid

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/26_bundle_under_sensemaking.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/26_bundle_under_sensemaking.yaml
@@ -1,0 +1,10 @@
+name: 26_bundle_under_sensemaking
+description: 26 bundle under sensemaking
+depends_on:
+- 24_bundles
+- 11_phase_sensemaking
+idempotent: true
+source_match: 'match $cc isa scilit-corpus, has id "collection-b329eae9911b"; $kp isa scilit-paper; (collection: $cc, member: $kp) isa alh-collection-membership; $k isa scilit-investigation, has scilit-investigation-type "deep-dive"; not { $k has id "scinv-3e0aa419866c"; }; (note: $k, subject: $kp) isa alh-aboutness;  fetch { "f_kid": $k.id };'
+target_insert: 'match $ph isa scilit-investigation-phase, has id "scphase-hallmarks-sensemaking"; $b isa scilit-paper-sensemaking, has id $f_kid; insert (phase: $ph, sensemaking: $b) isa scilit-phase-sensemaking;'
+skolem_keys:
+- f_kid

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/27_reported_claims.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/27_reported_claims.yaml
@@ -1,0 +1,8 @@
+name: 27_reported_claims
+description: 27 reported claims
+depends_on: []
+idempotent: true
+source_match: 'match $cc isa scilit-corpus, has id "collection-b329eae9911b"; $kp isa scilit-paper; (collection: $cc, member: $kp) isa alh-collection-membership; $k isa scilit-investigation, has scilit-investigation-type "deep-dive"; not { $k has id "scinv-3e0aa419866c"; }; (note: $k, subject: $kp) isa alh-aboutness;  (parent-note: $k, child-note: $cl) isa alh-note-threading; $cl isa scilit-claim, has scilit-claim-statement $s, has scilit-claim-type $t; fetch { "f_id": $cl.id, "f_stmt": $s, "f_type": $t };'
+target_insert: insert $cl isa scilit-reported-claim, has id $f_id, has scilit-claim-statement $f_stmt, has scilit-claim-type $f_type, has created-at 2026-06-26T12:00:00;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/28_bundle_reported_claim.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/28_bundle_reported_claim.yaml
@@ -1,0 +1,11 @@
+name: 28_bundle_reported_claim
+description: 28 bundle reported claim
+depends_on:
+- 24_bundles
+- 27_reported_claims
+idempotent: true
+source_match: 'match $cc isa scilit-corpus, has id "collection-b329eae9911b"; $kp isa scilit-paper; (collection: $cc, member: $kp) isa alh-collection-membership; $k isa scilit-investigation, has scilit-investigation-type "deep-dive"; not { $k has id "scinv-3e0aa419866c"; }; (note: $k, subject: $kp) isa alh-aboutness;  (parent-note: $k, child-note: $cl) isa alh-note-threading; $cl isa scilit-claim; fetch { "f_kid": $k.id, "f_cid": $cl.id };'
+target_insert: 'match $b isa scilit-paper-sensemaking, has id $f_kid; $cl isa scilit-reported-claim, has id $f_cid; insert (sensemaking: $b, reported-claim: $cl) isa scilit-sensemaking-reported-claim;'
+skolem_keys:
+- f_kid
+- f_cid

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/29_reported_gaps.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/29_reported_gaps.yaml
@@ -1,0 +1,8 @@
+name: 29_reported_gaps
+description: 29 reported gaps
+depends_on: []
+idempotent: true
+source_match: 'match $cc isa scilit-corpus, has id "collection-b329eae9911b"; $kp isa scilit-paper; (collection: $cc, member: $kp) isa alh-collection-membership; $k isa scilit-investigation, has scilit-investigation-type "deep-dive"; not { $k has id "scinv-3e0aa419866c"; }; (note: $k, subject: $kp) isa alh-aboutness;  (parent-note: $k, child-note: $g) isa alh-note-threading; $g isa scilit-gap, has scilit-knowledge-goal $kg, has name $nm; fetch { "f_id": $g.id, "f_goal": $kg, "f_name": $nm };'
+target_insert: insert $g isa scilit-reported-gap, has id $f_id, has scilit-knowledge-goal $f_goal, has name $f_name, has created-at 2026-06-26T12:00:00;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/30_bundle_reported_gap.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/30_bundle_reported_gap.yaml
@@ -1,0 +1,11 @@
+name: 30_bundle_reported_gap
+description: 30 bundle reported gap
+depends_on:
+- 24_bundles
+- 29_reported_gaps
+idempotent: true
+source_match: 'match $cc isa scilit-corpus, has id "collection-b329eae9911b"; $kp isa scilit-paper; (collection: $cc, member: $kp) isa alh-collection-membership; $k isa scilit-investigation, has scilit-investigation-type "deep-dive"; not { $k has id "scinv-3e0aa419866c"; }; (note: $k, subject: $kp) isa alh-aboutness;  (parent-note: $k, child-note: $g) isa alh-note-threading; $g isa scilit-gap; fetch { "f_kid": $k.id, "f_gid": $g.id };'
+target_insert: 'match $b isa scilit-paper-sensemaking, has id $f_kid; $g isa scilit-reported-gap, has id $f_gid; insert (sensemaking: $b, reported-gap: $g) isa scilit-sensemaking-reported-gap;'
+skolem_keys:
+- f_kid
+- f_gid

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/31_observations.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/31_observations.yaml
@@ -1,0 +1,8 @@
+name: 31_observations
+description: 31 observations
+depends_on: []
+idempotent: true
+source_match: 'match $cc isa scilit-corpus, has id "collection-b329eae9911b"; $kp isa scilit-paper; (collection: $cc, member: $kp) isa alh-collection-membership; $k isa scilit-investigation, has scilit-investigation-type "deep-dive"; not { $k has id "scinv-3e0aa419866c"; }; (note: $k, subject: $kp) isa alh-aboutness;  (parent-note: $k, child-note: $o) isa alh-note-threading; $o isa scilit-observation, has scilit-knowledge-level $kl, has scilit-bio-scale $bs, has name $nm, has content $c; fetch { "f_id": $o.id, "f_kl": $kl, "f_bs": $bs, "f_name": $nm, "f_content": $c };'
+target_insert: insert $o isa scilit-observation, has id $f_id, has name $f_name, has content $f_content, has scilit-knowledge-level $f_kl, has scilit-bio-scale $f_bs, has created-at 2026-06-26T12:00:00;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/32_bundle_observation.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/32_bundle_observation.yaml
@@ -1,0 +1,11 @@
+name: 32_bundle_observation
+description: 32 bundle observation
+depends_on:
+- 24_bundles
+- 31_observations
+idempotent: true
+source_match: 'match $cc isa scilit-corpus, has id "collection-b329eae9911b"; $kp isa scilit-paper; (collection: $cc, member: $kp) isa alh-collection-membership; $k isa scilit-investigation, has scilit-investigation-type "deep-dive"; not { $k has id "scinv-3e0aa419866c"; }; (note: $k, subject: $kp) isa alh-aboutness;  (parent-note: $k, child-note: $o) isa alh-note-threading; $o isa scilit-observation; fetch { "f_kid": $k.id, "f_oid": $o.id };'
+target_insert: 'match $b isa scilit-paper-sensemaking, has id $f_kid; $o isa scilit-observation, has id $f_oid; insert (sensemaking: $b, observation: $o) isa scilit-sensemaking-observation;'
+skolem_keys:
+- f_kid
+- f_oid

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/33_kefed_models.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/33_kefed_models.yaml
@@ -1,0 +1,8 @@
+name: 33_kefed_models
+description: 33 kefed models
+depends_on: []
+idempotent: true
+source_match: 'match $cc isa scilit-corpus, has id "collection-b329eae9911b"; $kp isa scilit-paper; (collection: $cc, member: $kp) isa alh-collection-membership; $k isa scilit-investigation, has scilit-investigation-type "deep-dive"; not { $k has id "scinv-3e0aa419866c"; }; (note: $k, subject: $kp) isa alh-aboutness; (parent-note: $k, child-note: $o) isa alh-note-threading; $o isa scilit-observation; (observation: $o, model: $m) isa kefed-observed-via;  $m isa kefed-model, has name $nm; fetch { "f_id": $m.id, "f_name": $nm };'
+target_insert: insert $m isa kefed-model, has id $f_id, has name $f_name, has created-at 2026-06-26T12:00:00;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/34_kefed_observed_via.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/34_kefed_observed_via.yaml
@@ -1,0 +1,11 @@
+name: 34_kefed_observed_via
+description: 34 kefed observed via
+depends_on:
+- 31_observations
+- 33_kefed_models
+idempotent: true
+source_match: 'match $cc isa scilit-corpus, has id "collection-b329eae9911b"; $kp isa scilit-paper; (collection: $cc, member: $kp) isa alh-collection-membership; $k isa scilit-investigation, has scilit-investigation-type "deep-dive"; not { $k has id "scinv-3e0aa419866c"; }; (note: $k, subject: $kp) isa alh-aboutness; (parent-note: $k, child-note: $o) isa alh-note-threading; $o isa scilit-observation; (observation: $o, model: $m) isa kefed-observed-via;  fetch { "f_oid": $o.id, "f_mid": $m.id };'
+target_insert: 'match $o isa scilit-observation, has id $f_oid; $m isa kefed-model, has id $f_mid; insert (observation: $o, model: $m) isa kefed-observed-via;'
+skolem_keys:
+- f_oid
+- f_mid

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/35_kefed_variables.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/35_kefed_variables.yaml
@@ -1,0 +1,8 @@
+name: 35_kefed_variables
+description: 35 kefed variables
+depends_on: []
+idempotent: true
+source_match: 'match $cc isa scilit-corpus, has id "collection-b329eae9911b"; $kp isa scilit-paper; (collection: $cc, member: $kp) isa alh-collection-membership; $k isa scilit-investigation, has scilit-investigation-type "deep-dive"; not { $k has id "scinv-3e0aa419866c"; }; (note: $k, subject: $kp) isa alh-aboutness; (parent-note: $k, child-note: $o) isa alh-note-threading; $o isa scilit-observation; (observation: $o, model: $m) isa kefed-observed-via;  (model: $m, variable: $v) isa kefed-element; $v isa kefed-variable, has name $nm, has kefed-variable-role $r; fetch { "f_id": $v.id, "f_name": $nm, "f_role": $r };'
+target_insert: insert $v isa kefed-variable, has id $f_id, has name $f_name, has kefed-variable-role $f_role, has created-at 2026-06-26T12:00:00;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/36_kefed_var_valueset.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/36_kefed_var_valueset.yaml
@@ -1,0 +1,9 @@
+name: 36_kefed_var_valueset
+description: 36 kefed var valueset
+depends_on:
+- 35_kefed_variables
+idempotent: true
+source_match: 'match $cc isa scilit-corpus, has id "collection-b329eae9911b"; $kp isa scilit-paper; (collection: $cc, member: $kp) isa alh-collection-membership; $k isa scilit-investigation, has scilit-investigation-type "deep-dive"; not { $k has id "scinv-3e0aa419866c"; }; (note: $k, subject: $kp) isa alh-aboutness; (parent-note: $k, child-note: $o) isa alh-note-threading; $o isa scilit-observation; (observation: $o, model: $m) isa kefed-observed-via;  (model: $m, variable: $v) isa kefed-element; $v isa kefed-variable, has kefed-value-set $vs; fetch { "f_id": $v.id, "f_vs": $vs };'
+target_insert: match $v isa kefed-variable, has id $f_id; insert $v has kefed-value-set $f_vs;
+skolem_keys:
+- f_id

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/37_kefed_element.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/37_kefed_element.yaml
@@ -1,0 +1,11 @@
+name: 37_kefed_element
+description: 37 kefed element
+depends_on:
+- 33_kefed_models
+- 35_kefed_variables
+idempotent: true
+source_match: 'match $cc isa scilit-corpus, has id "collection-b329eae9911b"; $kp isa scilit-paper; (collection: $cc, member: $kp) isa alh-collection-membership; $k isa scilit-investigation, has scilit-investigation-type "deep-dive"; not { $k has id "scinv-3e0aa419866c"; }; (note: $k, subject: $kp) isa alh-aboutness; (parent-note: $k, child-note: $o) isa alh-note-threading; $o isa scilit-observation; (observation: $o, model: $m) isa kefed-observed-via;  (model: $m, variable: $v) isa kefed-element; fetch { "f_mid": $m.id, "f_vid": $v.id };'
+target_insert: 'match $m isa kefed-model, has id $f_mid; $v isa kefed-variable, has id $f_vid; insert (model: $m, variable: $v) isa kefed-element;'
+skolem_keys:
+- f_mid
+- f_vid

--- a/local_resources/typedb/migration-rules/scilit-unified-investigation/38_hinges.yaml
+++ b/local_resources/typedb/migration-rules/scilit-unified-investigation/38_hinges.yaml
@@ -1,0 +1,11 @@
+name: 38_hinges
+description: 38 hinges
+depends_on:
+- 27_reported_claims
+- 02c_papers_hinge
+idempotent: true
+source_match: 'match $cc isa scilit-corpus, has id "collection-b329eae9911b"; $kp isa scilit-paper; (collection: $cc, member: $kp) isa alh-collection-membership; $k isa scilit-investigation, has scilit-investigation-type "deep-dive"; not { $k has id "scinv-3e0aa419866c"; }; (note: $k, subject: $kp) isa alh-aboutness;  (parent-note: $k, child-note: $cl) isa alh-note-threading; $cl isa scilit-claim; (hinging-claim: $cl, hinged-to: $tt) isa scilit-hinge; $tt has id $tid; fetch { "f_cid": $cl.id, "f_tid": $tid };'
+target_insert: 'match $cl isa scilit-reported-claim, has id $f_cid; $tt isa scilit-paper, has id $f_tid; insert (hinging-claim: $cl, hinged-to: $tt) isa scilit-hinge;'
+skolem_keys:
+- f_cid
+- f_tid


### PR DESCRIPTION
Adds the `scilit-unified-investigation` GLAV migration-rules bundle (40 rule files under `local_resources/typedb/migration-rules/`) and the scilit KEfED/OOEVV reconfiguration design records: the reconfiguration spec + plans (schema reconfiguration, CLI realignment, kefed-model-node, part3a polish, part3b runbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)