### PR TITLE
GoblinPack: Gobtown founding-era supplement design + campaign roster

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,20 +1,6 @@
 {
   "hooks": {
     "SessionStart": [
-<<<<<<< Updated upstream
-=======
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "REPO=$(git rev-parse --show-toplevel 2>/dev/null) && CORE=\"$REPO/local_skills/alhazen-core/alhazen_core.py\" && [ -f \"$CORE\" ] && cd \"$REPO\" && unset VIRTUAL_ENV && uv run --project \"$REPO/local_skills/alhazen-core\" python \"$CORE\" init",
-            "timeout": 90000
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
->>>>>>> Stashed changes
       {
         "hooks": [
           {

--- a/docs/superpowers/specs/2026-07-26-goblinpack-supplement-design.md
+++ b/docs/superpowers/specs/2026-07-26-goblinpack-supplement-design.md
@@ -171,6 +171,86 @@ recorded as the third, which is why Thekla is extraordinary.
 
 ---
 
+## 5A. The CHA re-baseline — the supplement's signature rule
+
+**Decided 2026-07-26.** This is the mechanical statement of the whole supplement, and it is a
+*decomposition of the printed numbers rather than an invention*.
+
+### The evidence
+
+Across the six statted goblinoids, **CHA is the only characteristic that is uniformly floored.**
+
+| | Goblin | Hobgoblin | Orc | Bugbear | Gnoll |
+|---|---|---|---|---|---|
+| STR | 8 | 13 | 14 | 19 | 15 |
+| SIZ | 8 | 17 | 14 | 21 | 20 |
+| INT | 12 | 13 | 11 | 10 | 10 |
+| **CHA** | **7** | **7** | **7** | **7** | **7** |
+
+Strength spans 8–19, size 8–21, intellect 10–13. Every species is differentiated on every axis
+except one, where all five collapse to an identical `2d6`. That is not a physiological observation.
+**It is a measurement taken from outside.**
+
+### The rule
+
+> **Goblinoid CHA is `3d6`.** Apply **−4 CHA** for all purposes when dealing with a culture not
+> your own. The penalty is **symmetric**: non-goblinoids take the same −4 toward goblinoids.
+
+`3d6` averages 11. Less 4 is 7 — **exactly the printed value.** A GM running vanilla Classic
+Fantasy sees an unchanged goblin. The book is not wrong; it is *incomplete*, having recorded
+goblinoids as their enemies experience them.
+
+Mutual incomprehension, not goblinoid deficiency: a human noble is as tongue-tied in a warren as a
+goblin is at court. "Everyone hates us" becomes a two-way mechanical fact rather than a complaint.
+
+### What it repairs
+
+CHA drives Influence (CHA×2), Deceit and Commerce (INT+CHA), Sing (POW+CHA), Dance, Courtesy,
+Native Tongue, and the Experience Modifier.
+
+1. **The learning penalty.** Experience Modifier is +1 at CHA 13–18. At `2d6` a goblinoid **caps at
+   12** — so under the printed numbers no goblinoid of any species could ever have a positive
+   learning modifier, while humans routinely do. The re-baseline removes a quiet claim that
+   goblinoids are worse at learning.
+2. **Vykthar's prerequisite.** CHA 14 was unreachable at `2d6` (max 12) — by RAW nobody could join
+   the cult of the goddess of goblinoid storytelling. At `3d6` it is reachable, and reachable
+   precisely by those compelling *among their own people*, which is what a boast-singer is. The
+   requirement was never broken; we were measuring with the wrong ruler. **Closes open question 2.**
+3. **The goblinoid Bard becomes viable** — the first class on the v0 list, previously impossible.
+4. **Thekla Morvani, explained.** Raised across both cultures, she takes **no penalty in either
+   direction**. In any room containing both species she is functionally the most charismatic person
+   present — not because her CHA is high, but because everyone else's collapses. That is why a duke
+   who despises goblinoids keeps one at his elbow, and it is a far better warrant for the narrator
+   than "she is persuasive."
+
+### Scope note
+
+Applies to CHA only. The other characteristics are differentiated across species and show no sign
+of the same flattening, so there is no evidence to justify extending the treatment.
+
+---
+
+## 5B. Why goblinoid classes are structurally different
+
+Human and demi-human classes are **vocational**: you trained, you joined, you swore an oath.
+Goblinoid classes are **functional**, following directly from the first virtue — *to be valued in a
+goblinoid community is primarily utilitarian: do something well and you may live a little longer.*
+Nobody trains a goblin. A goblin becomes useful, or dies.
+
+| | Demi-human classes | Goblinoid classes |
+|---|---|---|
+| Entry | training, guild, apprenticeship | demonstrated usefulness |
+| Oaths | sworn, binding, class-defining | none — cult *favour* instead, which is withdrawn not broken |
+| Tenure | permanent once earned | **provisional; lost when your function is not needed** |
+| Naming | vocation (Fighter, Cleric) | function (Wolf Rider, Crafter, Boast-singer) |
+
+**Provisional tenure is the load-bearing difference.** A class you can lose turns the Wolf Rider's
+obsolescence in Khorvenn's tunnels and Ghazrek's grievance into the same mechanic, and it makes
+retraining — Experience Rolls spent on new Professional skills — a status question rather than a
+bookkeeping one. A traditionalist is simply someone who refuses to spend them.
+
+---
+
 ## 6. Part Two — Equipment and Magic (seed only)
 
 The one genuinely original idea here is **anti-craftsmanship**, implicit in Grottendacz's doctrine:
@@ -253,7 +333,8 @@ correctly regard it as a death.
 ## 9. Open questions
 
 1. **Vykthar: Cleric or Bard?** (§5.2) Blocks Thekla's final sheet and the cult chapter.
-2. **Vykthar's CHA 14 prerequisite** is unreachable for the races it accepts (§5.3).
+2. ~~**Vykthar's CHA 14 prerequisite**~~ **Resolved by the CHA re-baseline** (§5A) — reachable at
+   `3d6`, and reachable exactly by those compelling among their own people.
 3. **Load CF core rules into the graph.** The 348 loaded pieces are Imperative and now diverge from
    the target system.
 4. **Origins and Mythology** needs writing from a one-line seed (§4.2).

--- a/docs/superpowers/specs/2026-07-26-goblinpack-supplement-design.md
+++ b/docs/superpowers/specs/2026-07-26-goblinpack-supplement-design.md
@@ -1,0 +1,267 @@
+# GoblinPack — Supplement Design Spec
+
+**Date:** 2026-07-26
+**System:** Mythras **Classic Fantasy** (TDM500 core — *not* the Imperative SRD; see §3)
+**Status:** Skeleton + progress tracker. Chapter specs hang off this document.
+**Chapter spec:** Gobtown founding era → [`2026-07-26-gobtown-origins-design.md`](2026-07-26-gobtown-origins-design.md)
+
+> **Scope correction (2026-07-26).** Earlier work treated Gobtown as the whole project. It is not.
+> GoblinPack is a **full Classic Fantasy supplement**; Gobtown is one setting inside Part Three.
+> This document is the supplement; the Gobtown spec is a chapter of it.
+
+---
+
+## 1. What the supplement is
+
+A Classic Fantasy supplement in which goblinoids are **protagonists** rather than battle-fodder.
+
+> "Rather than thinking of them as simple, flat monsters that we whet the edges of our blades
+> upon, we will watch them, talk to them, become them." — v0 draft
+
+Dedication, from v0: *for those who have been misunderstood, reviled, and oppressed.*
+
+**Narrated throughout by Thekla Morvani**, half-orc Grand Prevaricator of Vykthar and advisor on
+goblinoid matters to Duke Aldric Kessarin. A Prevaricator is a professional myth-maker, so the
+narrator is **unreliable by doctrine** — every chapter is advocacy aimed at a hostile human court
+by a priestess whose goddess rewards the tale told well.
+
+**Terminology (v0):** *goblinoid* = goblins, hobgoblins, koolinth, bugbears, orcs, orogs.
+Deliberately excludes gnolls, flinds, kobolds, giants, ogres, ettins, trolls, though they are
+often found together. *Gobbo* is the colloquial term used throughout.
+
+---
+
+## 2. Structure and progress
+
+Skeleton follows v0's table of contents. Status is honest: most of this is not written.
+
+| Part | Chapter | Status |
+|---|---|---|
+| **One** | Overview & Introduction | ✅ framing + Thekla's voice settled |
+| | Good and Evil for Goblinoids | ✅ **designed** — five virtues, contextual hatred, Evil-is-not-psychopathy |
+| | Origins and Mythology | ⛔ **seed only** — see §4 |
+| | Goblinoid Races | ✅ **designed** — six races, real stats, conversion method |
+| | Half Breeds and Mixed Heritage | ✅ **designed** |
+| | Relations with Giant-Kin | ⛔ not started |
+| **Two** | Character Creation | 🟡 races + cultures done; class packages outstanding |
+| | Goblinoid Character Classes | 🟡 **decided, not written** — see §5 |
+| | Organizations and Cults | 🟡 10 cults digested; theological politics outstanding |
+| | Equipment and Magic | ⛔ **seed only** — anti-craftsmanship, see §6 |
+| **Three** | Goblinoid Territories | 🟡 Kazhrun sketched, tribal lands outstanding |
+| | Tribal Lands | ⛔ not started |
+| | **GobTown** | ✅ **full chapter spec + database populated** |
+| | Gobbo Adventures | 🟡 frames catalogued; two scenarios written — see §7 |
+
+---
+
+## 3. System decision: full Classic Fantasy, not the Imperative
+
+**Decided 2026-07-26.** The supplement targets **CF core (TDM500)**.
+
+The deciding evidence was v0's own class list, which contains **Bard** and **Thief-Acrobat** —
+classes that exist in CF core and *not* in the four-class Imperative SRD. Writing to CFI would
+have silently deleted two of the eight archetypes already designed.
+
+**What this costs, and must be honoured downstream:**
+
+- **Single-axis Moral Philosophy** (Good / Neutral / Evil + one or two traits), not CFI's two-axis
+  Ethical + Moral alignment. Any rule written against the two-axis model needs rewriting. *Done —
+  both the Gobtown roster and the chapter spec (rev. 3).*
+- **Infravision**, not Darkvision.
+- **Not ORC-licensed.** Publishing needs TDM clearance — likely available given the existing
+  relationship, but it is no longer automatic.
+- **The loaded rules graph is CFI**, 348 pieces in `alh_mythras` tagged `classic-fantasy`. It will
+  answer with Imperative rules, which now diverge from the target system. Loading CF core as a
+  second rules corpus is an open task (§9).
+
+---
+
+## 4. Part One — Good and Evil, and the origins gap
+
+### 4.1 Designed: the moral psychology
+
+The supplement's intellectual core, and the strongest existing material. Goblinoids are not
+immoral; they weight the moral foundations differently. The five virtues:
+
+| Virtue | Expression |
+|---|---|
+| Shut up and get on with it | Actions over ideals. Do your job or I'll kill you. |
+| Be the biggest / sneakiest bastard you can | Rewards go to those who take and hold them |
+| Have fun — extra points for comedy value | Cruelty is funnier when well-timed |
+| Don't be a picky eater | Scarcity is permanent. Cannibalism is normal; squeamishness is contemptible |
+| Everyone hates us | So it is delicious to outthink, crush, or eat those who think themselves better |
+
+Two load-bearing clarifications, both from the user's design notes:
+
+- **Tribal hatred is contextual, not innate.** How hate-filled a group is depends on leadership,
+  scarcity and history — not species. Two warbands over one valley will slaughter each other; the
+  same two under a competent captain may not.
+- **The Evil passion is not psychopathy.** Pre-modern humans enjoyed public executions without
+  being unable to love their children. Cruelty is a spectator taste and a tool, directed by
+  cultural rules about *who is fair game*.
+
+Goblinoids reject the label "evil" as effete elvish propaganda, and given the historical conduct
+of elves and humans toward them, the reader is not obliged to disagree.
+
+### 4.2 Seed only: Origins and Mythology
+
+v0 gives one line, and it is a good one:
+
+> "Goblinoids have a pragmatic view of their origins, preferring comedic, bawdy creation myths
+> involving raucous sex and or defecation to harmonious stories involving beauty."
+
+**Undeveloped.** Needs at least: two or three competing creation myths (mutually contradictory and
+cheerfully so), how they explain the relationship to giant-kin, and what they say about why
+everyone hates them. **Design note:** these myths should be *funny and load-bearing* — Vykthar's
+cult exists to keep telling them, and the Gobtown chapter turns on who controls the story.
+
+---
+
+## 5. Part Two — Classes
+
+v0's eight archetypes, mapped against CF core:
+
+| v0 archetype | CF class | Status |
+|---|---|---|
+| Bard / Entertainer / Courtesan / Jester / Fool | **Bard** | exists — needs goblinoid write-up |
+| Cleric / Priest / Shaman | **Cleric** | exists |
+| Fighter / Warrior | **Fighter** | exists |
+| Magic User / Alchemist | **Magic-User** | exists |
+| Thief / Agent / Hunter / Scout | **Thief** | exists |
+| Thief Acrobat | **Thief-Acrobat** | exists |
+| Beast Handler / Wolf Rider | — | 🆕 **new class** |
+| Merchant / Crafter / Miner | — | 🆕 **new class** |
+
+**Closed to goblinoids:** **Paladin** (Lawful Good is unreachable) and **Druid** — the rulebook
+states it directly: *"most monster races cannot be Druids in a typical Classic Fantasy campaign"*;
+convert to Cleric.
+
+### 5.1 The two new classes carry the supplement's argument
+
+**Wolf Rider (Beast Handler).** Goblins are canonically dire-wolf cavalry and no CF class covers
+mounted beast-partnership. This is a genuinely goblinoid contribution — and it is a **Kazhrun**
+class: it needs open ground and a wolf.
+
+**Merchant / Crafter / Miner.** No CF class covers the productive civilian, because adventurers do
+not have jobs. This is the **Gobtown** class — barely meaningful in the tribal lands, and the
+entire basis of a settlement that has stopped raiding. It already has a god in Grottendacz.
+
+**The two are a matched pair, and the pair is the supplement's thesis in mechanical form.** Wolf
+Rider is what goblinoids *were*; Crafter is what a goblinoid civilisation *requires*. A campaign
+that moves from the tribal lands to Gobtown is a campaign in which the first class becomes
+obsolete and the second becomes essential — and a traditionalist is mechanically just a character
+who refuses to spend Experience Rolls on retraining. (Worked through in the Gobtown chapter, where
+Ghazrek's grievance is professional rather than ideological, and he is not wrong.)
+
+### 5.2 Open: are Vykthar's clergy Clerics or Bards?
+
+Vykthar governs boasting, tall tales and myth-making; her cult skills are Oratory, Performance,
+Influence, Insight, Carousing, Boast. Her v0 gifts are Command, Charm Being, Inspiration. **That
+is a Bard, wearing a Cleric's title.** v0 writes her up with cleric prerequisites and a Rank-based
+gift ladder, which is the Cleric chassis. Needs a decision: Cleric, Bard, or a Bard variant with
+Devotion. Thekla Morvani is currently statted as a Cleric pending the call.
+
+### 5.3 Rules snag — Vykthar's prerequisites are unreachable
+
+v0 sets Vykthar's requirements at **POW 12, CHA 14**. But *every goblinoid rolls CHA 2d6*, maximum
+12, and even a half-orc caps at 13. **By RAW no pure goblinoid can ever qualify for the cult of the
+goddess of goblinoid storytelling.** Options: lower to CHA 12; treat the excess as a divine gift
+that raises the characteristic; or keep it and make Prevaricators near-mythical — currently
+recorded as the third, which is why Thekla is extraordinary.
+
+---
+
+## 6. Part Two — Equipment and Magic (seed only)
+
+The one genuinely original idea here is **anti-craftsmanship**, implicit in Grottendacz's doctrine:
+*build 'em fast and if they break, so what.*
+
+**Undeveloped, and worth real attention.** Goblinoid manufacture optimises for speed, disposability
+and immediate advantage rather than durability or beauty — which is not incompetence, it is a
+different objective function, and it follows directly from the five virtues. Needs: mechanical
+treatment (reduced AP/HP on goblinoid-made gear, offset by cost and availability? breakage on a
+fumble?), what goblinoids consider *good* work, and why their weapons are nonetheless prized
+exports in the Year 12 city.
+
+---
+
+## 7. Part Three — Territories and adventures
+
+### 7.1 The five campaign frames
+
+From v0 and the game-types document, reconciled:
+
+| Frame | Template | Status |
+|---|---|---|
+| Reverse dungeoneering — adventurers attack *your* home | *Leverage* | catalogued |
+| In the service of the dark lord — disposable PCs, insane overlord | *Paranoia* / *Better Call Saul* | catalogued |
+| Crime capers | *Ocean's Eleven* / Guy Ritchie | catalogued |
+| War — military campaign against smug elves and humans | — | catalogued |
+| **Goblinball** — the closest thing to a recreational sport | — | ⛔ **undeveloped, and a shame** |
+
+### 7.2 Territories
+
+- **The Kazhrun** — the mountain heartland. Chaotic, disorganised, permanently at war with itself;
+  no institution outlives the chief who founded it. **Tribal Lands chapter not started.**
+- **Gobtown** — the founding-era settlement, 50–100 souls in the caves of Khorvenn. **Fully specced
+  and populated in the database.** See the chapter spec.
+
+### 7.3 Written scenarios
+
+Both belong to Gobtown; see the chapter spec for detail.
+
+- **"The Wrong Cathedral"** (cold open) — a cleric of Ehrendil arrives expecting a grove and a
+  choir, and finds a goblin warren with her god unmistakably inside it.
+- **"The Emissary"** — Thekla walks in. She cannot be eaten because she decides whether Gobtown
+  becomes a legend, and the secret leaks through vanity rather than spycraft.
+
+---
+
+## 8. Database state
+
+Campaign `goblinpak` = `myth-campaign-f0745885c38a` in `alh_mythras`, flag `classic-fantasy`.
+
+**Populated 2026-07-26:** 12 founding-era characters with CF single-axis Moral Philosophy, CF class
+names, derived stats computed from the validated tables, and narratives in `content`.
+
+| Character | Race | Class | Moral Philosophy |
+|---|---|---|---|
+| Magnificus Drakmoor | hobgoblin | Fighter | Evil (Heartless and Slaver) **39** — heavily waned |
+| The Wellspring | celestial | — | Good (Saintly) 90 — *GM only, never roll against it* |
+| Thekla Morvani | half-orc | Cleric | Evil (Chaotic and Spiteful) 60 |
+| Duke Aldric Kessarin | human | Fighter | Neutral (Unbiased and Pompous) 54 |
+| Ghazrek | orc | Fighter | Evil (Bloodthirsty and Slaver) **62** — has *not* waned |
+| Sister Ilenne Vasch | human | Cleric | Good (Kind and Honest) 62 |
+| Vharza | hobgoblin | Fighter | Evil (Heartless) 44 |
+| Nubrik | goblin | Thief | Evil (Spiteful and Cannibalistic) 47 |
+| Brogg | bugbear | Fighter | Evil (Heartless and Murderous) 46 |
+| Skell | koolinth | Thief | Evil (Cannibalistic and Heartless) 50 |
+| Ozmek | orc × goblin | Thief | Evil (Spiteful) **33** — closest to losing it |
+| Zhara | goblin | Magic-User | Evil (Wicked and Chaotic) 55 |
+
+The 13 Year 12 NPCs are retained and tagged `[YEAR 12 FUTURE CANON]`.
+
+**The Moral Philosophy numbers are the campaign, told in one column.** Ghazrek's is elevated;
+Drakmoor's and Ozmek's are collapsing. CF's own rule — *"if the chosen philosophy is reduced to 0,
+a new one replaces it at base level, per the character's recent actions"* — means the Concord does
+not redeem anyone. It erases their Evil and installs Neutral: still Greedy, Dishonest, Self-centred,
+no longer Cruel and Slaver. **Civilisation without redemption, entirely RAW.** Ghazrek would
+correctly regard it as a death.
+
+---
+
+## 9. Open questions
+
+1. **Vykthar: Cleric or Bard?** (§5.2) Blocks Thekla's final sheet and the cult chapter.
+2. **Vykthar's CHA 14 prerequisite** is unreachable for the races it accepts (§5.3).
+3. **Load CF core rules into the graph.** The 348 loaded pieces are Imperative and now diverge from
+   the target system.
+4. **Origins and Mythology** needs writing from a one-line seed (§4.2).
+5. **Equipment: anti-craftsmanship** needs a mechanical treatment (§6).
+6. **Tribal Lands** chapter not started — and the supplement needs it, since it is the *default*
+   goblinoid setting and Gobtown is the exception.
+7. **Goblinball.** Undeveloped and the single most likely thing in this document to sell the
+   supplement to a browsing reader.
+8. **Relations with Giant-Kin** not started.
+9. ~~Gobtown spec §5.8~~ **Done** — chapter spec retargeted to CF core at rev. 3; the alignment
+   rider is now sourced from the core book's own Moral Philosophy replacement rule.

--- a/docs/superpowers/specs/2026-07-26-goblinpack-supplement-design.md
+++ b/docs/superpowers/specs/2026-07-26-goblinpack-supplement-design.md
@@ -353,11 +353,46 @@ Light armour only — anything heavier and the wolf will not carry you far enoug
 - **The Long Ride** (Rank 4). Mounted travel at forced pace without Endurance penalty for a number
   of days equal to CON/3.
 
-> **Obsolescence is a feature.** A Wolf Rider needs open ground and a wolf. In Khorvenn's galleries
-> he is a man with a large dog in a corridor: *Ride-By*, *The Long Ride* and most of *Pack Tactics*
-> are unusable underground, and the wolf itself is a mouth that eats meat the settlement cannot
-> spare. This is the mechanical root of Ghazrek's grievance, and he is not wrong — his class does
-> not work here.
+> **This class is Gobtown's outer wall.** The settlement survives by not being found, and not
+> being found requires knowing who is coming. The outriders hold the approaches — the pass mouth,
+> the goat tracks, the lower valleys, the road where caravans move — and they are away for days at
+> a stretch. Every talent above works exactly as written, because open country is where these
+> characters actually spend their working lives. Khorvenn's galleries are where they sleep.
+
+**What is constrained is permission, not capability.** An outrider sees a fat merchant train on the
+low road and is forbidden to touch it, because a raid brings a punitive expedition and the whole
+experiment ends. He has the strength to take and standing orders not to.
+
+**That is Ghazrek's grievance, and it is far worse than uselessness.** He is a warrior employed as
+a watchman. He does his job perfectly and it earns him nothing, because *Be The Biggest Bastard You
+Can* cannot be satisfied by withdrawing quietly and reporting accurately, and Vykthar has no song
+for a man who watched. His passion is unexercisable in his own profession. A goblinoid whose
+defining virtue has no outlet is not merely frustrated — by his own culture's reckoning he is
+becoming nobody.
+
+### 5C.2a The dosage problem — why the outriders are the traditionalists
+
+**The Concord is in the water** (Gobtown chapter §4). Outriders spend days at a time away from it,
+carrying skins filled before they left and drinking from streams once those run out.
+
+They come back **edgy, quarrelsome, and hungry in the wrong way.** The decay clock from the Gobtown
+chapter runs on individuals as well as the settlement, and the outriders are the only residents who
+routinely trigger it.
+
+The consequence is a faction that assembles itself without anyone deciding to found one:
+
+- The outriders are the **least civilised goblinoids in Gobtown** — not by conviction, but by
+  *exposure*. They are the least-dosed members of the population.
+- They are also the ones with **weapons, mounts, mobility, and knowledge of every route in and out**.
+- They have the **best reason to distrust the dawn ritual**, since they feel the difference between
+  being home and being away most sharply, and nobody has ever explained it to them.
+- And **none of them understands why they feel this way**, including Ghazrek. They experience it as
+  clarity — as being the only ones who have not gone soft. From inside, waning is invisible; what
+  you notice is other people changing.
+
+> **This is the traditionalist faction, and it is a public-health problem wearing an ideology.**
+> Drakmoor cannot fix it without explaining the water. Rotating outriders home more often would
+> work, and he cannot order it without giving a reason.
 
 ### 5C.3 Crafter / Miner 🆕
 
@@ -410,12 +445,18 @@ the wrong way round. No armour restriction — you already work in it.
 
 Following §5B, class is **provisional**. A character whose function is no longer needed may retrain
 by spending **Experience Rolls** on the new class's Prerequisite Skills; rank is recalculated
-against the new ladder and will usually drop. A Wolf Rider who becomes a Digger starts at Rank 0 or
-1 and is publicly, visibly demoted.
+against the new ladder and will usually drop, leaving the character publicly demoted.
 
-**That humiliation is the point.** Retraining costs status in a society that allocates status by
-usefulness, which is why traditionalists refuse — and why the ones who accept it are the ones
-building something. Ghazrek has the Experience Rolls. He will not spend them.
+**Note what Gobtown does and does not make obsolete.** No class here is useless — the settlement
+needs outriders, diggers, singers and fighters, and needs them all badly at a population of a
+hundred. What changed is not which skills are wanted but **which skills earn status**. Raiding
+produced loot, songs and bragging rights; scouting produces a report. Mining keeps everyone alive
+and produces nothing anyone will sing about.
+
+**So the friction is a reward-structure problem, not a competence problem**, which is why it cannot
+be solved by retraining and why it festers. Ghazrek does not need new skills. He needs his existing
+ones to mean what they used to mean, and Gobtown cannot give him that without ceasing to be
+Gobtown.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-26-goblinpack-supplement-design.md
+++ b/docs/superpowers/specs/2026-07-26-goblinpack-supplement-design.md
@@ -44,9 +44,9 @@ Skeleton follows v0's table of contents. Status is honest: most of this is not w
 | | Half Breeds and Mixed Heritage | ✅ **designed** |
 | | Relations with Giant-Kin | ⛔ not started |
 | **Two** | Character Creation | 🟡 races + cultures done; class packages outstanding |
-| | Goblinoid Character Classes | 🟡 **decided, not written** — see §5 |
+| | Goblinoid Character Classes | 🟡 3 of 8 drafted (§5C): Prevaricator Bard, Wolf Rider, Crafter |
 | | Organizations and Cults | 🟡 10 cults digested; theological politics outstanding |
-| | Equipment and Magic | ⛔ **seed only** — anti-craftsmanship, see §6 |
+| | Equipment and Magic | 🟡 anti-craftsmanship now has a mechanism (§5C.3 *Fast and Filthy*) |
 | **Three** | Goblinoid Territories | 🟡 Kazhrun sketched, tribal lands outstanding |
 | | Tribal Lands | ⛔ not started |
 | | **GobTown** | ✅ **full chapter spec + database populated** |
@@ -251,6 +251,174 @@ bookkeeping one. A traditionalist is simply someone who refuses to spend them.
 
 ---
 
+## 5C. Class drafts
+
+Written against the CF class template (prose → weapon/armour restriction → Standard Skills →
+Professional Skills → Combat Style → Rank Structure → Prerequisite Skills → Abilities & Talents).
+The rank ladder follows the book's own progression: **5 skills @50%, 5 @70%, 4 @90%, 3 @110%,
+2 @130%**, with **+1 Luck Point per Rank**.
+
+### 5C.1 Bard — the Prevaricator Order (Vykthar)
+
+**Decided: Vykthar's clergy are Bards, not Clerics.** The chassis fits without modification —
+Oratory, Sing, Influence, Acting, Seduction, Sleight, and a talent ladder ending in Inspiration is
+a description of a boast-singer. The book already splits bards into an **Arcane College** and a
+**Druidic Order**, each with its own Professional list and magical source; GoblinPack adds a third.
+
+> **The Prevaricator Order.** Where civilised bards attend colleges and druidic bards keep The Old
+> Ways, Vykthar's boast-singers hold that a deed unremembered did not happen, and that a deed
+> remembered *badly* is a theft. They are the only institution in goblinoid society that reliably
+> outlives the chief who founded it, because they are the ones who decide what he was.
+
+**Standard Skills:** Athletics, Combat Style (Prevaricator), Deceit, Evade, Influence, Insight,
+Locale, Sing, Stealth
+
+**Professional Skills (Prevaricator):** Acting, Boast, Carousing, Channel, Lore (Goblinoid
+Histories), Musicianship (All), Oratory, Piety (Vykthar), Seduction, Streetwise
+
+Max 3 Professional skills and no extra Skill Points, as per all bards — master of none.
+
+**Combat Style (Prevaricator):** club, dagger, javelin, knife, shortsword, sling, spear, staff.
+Light armour only; a Prevaricator who cannot be heard is not working.
+
+**Divine casting** via Piety (Vykthar), on the druidic-bard pattern. Starting Rank 1 spells equal to
+1/20th Piety. **Spheres:** All, Charm, Protection — matching v0's cult entry.
+
+| Rank | Title | Max Spell | Prerequisites | Luck |
+|---|---|---|---|---|
+| 0 | Hanger-On | — | — | — |
+| 1 | Listener | Rank 1 | 5 skills at 50% | +1 |
+| 2 | Braggard | Rank 1 | 5 skills at 70% | +2 |
+| 3 | Warsinger | Rank 2 | 4 skills at 90% | +3 |
+| 4 | Scarkeeper | Rank 2 | 3 skills at 110% | +4 |
+| 5 | Grand Prevaricator | Rank 3 | 2 skills at 130% | +5 |
+
+**Prerequisite Skills:** Influence, Oratory, Piety (Vykthar), Sing, and either Boast or Acting.
+
+**Talents.** *Inspiration* and *Artful Dodger* as per the core Bard. Plus:
+
+- **Safe Conduct** (Rank 1). Vykthar extends protection to any audience, *including non-goblinoids*,
+  so that her stories may be heard in safety. While a Prevaricator is actively telling, violence
+  against the audience is sacrilege. This does not stop anyone — it makes them pay for it, and every
+  goblinoid present knows the price.
+- **The Version That Sticks** (Rank 2). Spend 3 Magic Points and succeed at Oratory to establish
+  your account of an event as the one the community remembers. Contradicting witnesses must overcome
+  your Oratory with an opposed roll to be believed, *even when they are telling the truth*.
+- **Name The Fool** (Rank 3). Name a target in a tale before an audience. Their Influence and
+  Courtesy operate one grade harder within that community until they do something worth retelling.
+  Goblinoid society has no legal punishment worse than this.
+- **Truthkeeper** (Rank 4, optional, secret). Access to the cult's hidden archives and the coded
+  scripts that maintain them. Members pose as ordinary storytellers while preserving histories that
+  would be destroyed if found. *Taking this talent is a GM-facing commitment, not a public rank.*
+
+> **Thekla Morvani is Rank 3 (Warsinger) and uses the Rank 5 title at the Valdenmark court.** She
+> has not earned it. Inflating your own legend is not a violation of Vykthar's doctrine — it is an
+> act of worship, and the only sin is being dull or getting caught.
+
+### 5C.2 Wolf Rider 🆕
+
+The Kazhrun class. Goblins are canonically dire-wolf cavalry and no CF class covers mounted
+beast-partnership; the Ranger comes closest and is wrong in every particular that matters.
+
+**Standard Skills:** Athletics, Combat Style (Wolf Rider), Endurance, Evade, Locale, Perception,
+Ride, Survival, Track
+
+**Professional Skills:** Animal Training, Commerce, Craft (Harness), Healing, Lore (Beasts),
+Navigate, Streetwise, Survival (Mountains)
+
+**Combat Style (Wolf Rider):** javelin, lance (light), net, shortbow, shortsword, sling, spear.
+Light armour only — anything heavier and the wolf will not carry you far enough to matter.
+
+| Rank | Title | Prerequisites | Luck |
+|---|---|---|---|
+| 0 | Whelp-tender | — | — |
+| 1 | Outrider | 5 skills at 50% | +1 |
+| 2 | Pack-second | 5 skills at 70% | +2 |
+| 3 | Wolf Rider | 4 skills at 90% | +3 |
+| 4 | Pack-leader | 3 skills at 110% | +4 |
+| 5 | Wolf-mother / Wolf-father | 2 skills at 130% | +5 |
+
+**Prerequisite Skills:** Animal Training, Athletics, Perception, Ride, Track.
+
+**Talents.**
+
+- **Bonded Mount** (Rank 1). A dire wolf companion with its own stat block. It is not equipment; it
+  has passions and will act on them. If it dies you lose all Wolf Rider talents until you raise
+  another from a whelp, which takes a season.
+- **Ride-By** (Rank 1). Move, attack and move again in one turn without granting a free attack,
+  provided the wolf ends outside engagement range.
+- **Pack Tactics** (Rank 2). When two or more Wolf Riders engage the same target, each gains an
+  augment. Goblinoids who cannot cooperate get nothing from this talent, which is exactly the point.
+- **Speak Wolf** (Rank 3). Not magic — fluency. Communicate complex intent to any canid.
+- **The Long Ride** (Rank 4). Mounted travel at forced pace without Endurance penalty for a number
+  of days equal to CON/3.
+
+> **Obsolescence is a feature.** A Wolf Rider needs open ground and a wolf. In Khorvenn's galleries
+> he is a man with a large dog in a corridor: *Ride-By*, *The Long Ride* and most of *Pack Tactics*
+> are unusable underground, and the wolf itself is a mouth that eats meat the settlement cannot
+> spare. This is the mechanical root of Ghazrek's grievance, and he is not wrong — his class does
+> not work here.
+
+### 5C.3 Crafter / Miner 🆕
+
+The Gobtown class, and the one that barely exists in the tribal lands. No CF class covers the
+productive civilian because adventurers do not have jobs. Patron: **Grottendacz** — build 'em fast,
+and if they break, so what.
+
+**Standard Skills:** Athletics, Brawn, Combat Style (Crafter), Endurance, Locale, Perception,
+Willpower, and either Evade or Swim
+
+**Professional Skills:** Commerce, Craft (any two), Engineering, Lore (Minerals), Mechanisms,
+Navigate (Underground), Piety (Grottendacz), Survival
+
+**Combat Style (Crafter):** hammer, mattock, pick, shortsword, shield, sling, staff. Tools, held
+the wrong way round. No armour restriction — you already work in it.
+
+| Rank | Title | Prerequisites | Luck |
+|---|---|---|---|
+| 0 | Hand | — | — |
+| 1 | Digger | 5 skills at 50% | +1 |
+| 2 | Shaper | 5 skills at 70% | +2 |
+| 3 | Crafter | 4 skills at 90% | +3 |
+| 4 | Master of Works | 3 skills at 110% | +4 |
+| 5 | Deepwright | 2 skills at 130% | +5 |
+
+**Prerequisite Skills:** Brawn, Craft (chosen), Engineering, Lore (Minerals), Mechanisms.
+
+**Talents.**
+
+- **Fast and Filthy** (Rank 1). *This is the anti-craftsmanship rule, and it belongs here.* Produce
+  any item you could normally craft in **one quarter** the time. The result has **half AP and half
+  HP**, and **breaks outright on a fumble**. Goblinoids do not regard this as inferior work. It is
+  correct work: the thing existed when it was needed, and a spear that survives one battle has
+  served its whole purpose.
+- **Read the Rock** (Rank 1). Assess structural soundness, load-bearing walls, gas pockets and
+  collapse risk at a glance. In Khorvenn this is the difference between a settlement and a grave.
+- **Improvise** (Rank 2). Substitute available junk for proper materials at one grade harder, with
+  no quality loss beyond what *Fast and Filthy* already imposes.
+- **Field Repair** (Rank 3). Restore a broken item to working order in minutes rather than hours.
+  Given the above, this talent sees constant use.
+- **Deep Sense** (Rank 4). Navigate unfamiliar tunnel systems without light and without becoming
+  lost; know your depth and bearing.
+
+> **This class is the settlement.** At 50–100 people every trade is one or two deep. Gobtown has
+> perhaps two competent Crafters, and if both are lost the tunnels stop being maintained, the
+> cisterns silt, and the fungus beds fail within a season. A traditionalist who sneers at diggers is
+> sneering at the reason he ate this morning.
+
+### 5C.4 Retraining and provisional tenure
+
+Following §5B, class is **provisional**. A character whose function is no longer needed may retrain
+by spending **Experience Rolls** on the new class's Prerequisite Skills; rank is recalculated
+against the new ladder and will usually drop. A Wolf Rider who becomes a Digger starts at Rank 0 or
+1 and is publicly, visibly demoted.
+
+**That humiliation is the point.** Retraining costs status in a society that allocates status by
+usefulness, which is why traditionalists refuse — and why the ones who accept it are the ones
+building something. Ghazrek has the Experience Rolls. He will not spend them.
+
+---
+
 ## 6. Part Two — Equipment and Magic (seed only)
 
 The one genuinely original idea here is **anti-craftsmanship**, implicit in Grottendacz's doctrine:
@@ -332,7 +500,8 @@ correctly regard it as a death.
 
 ## 9. Open questions
 
-1. **Vykthar: Cleric or Bard?** (§5.2) Blocks Thekla's final sheet and the cult chapter.
+1. ~~**Vykthar: Cleric or Bard?**~~ **Resolved: Bard**, as a third bardic order alongside the
+   Arcane College and the Druidic Order. Drafted at §5C.1.
 2. ~~**Vykthar's CHA 14 prerequisite**~~ **Resolved by the CHA re-baseline** (§5A) — reachable at
    `3d6`, and reachable exactly by those compelling among their own people.
 3. **Load CF core rules into the graph.** The 348 loaded pieces are Imperative and now diverge from

--- a/docs/superpowers/specs/2026-07-26-goblinpack-supplement-design.md
+++ b/docs/superpowers/specs/2026-07-26-goblinpack-supplement-design.md
@@ -485,7 +485,7 @@ From v0 and the game-types document, reconciled:
 | Reverse dungeoneering — adventurers attack *your* home | *Leverage* | catalogued |
 | In the service of the dark lord — disposable PCs, insane overlord | *Paranoia* / *Better Call Saul* | catalogued |
 | Crime capers | *Ocean's Eleven* / Guy Ritchie | catalogued |
-| War — military campaign against smug elves and humans | — | catalogued |
+| War — military campaign against smug elves and humans | — | 🟡 **the Standing and the Tithe** drafted in the Gobtown chapter §4.5 — goblinoid units that hold formation, obey cross-species orders and retrieve their wounded |
 | **Goblinball** — the closest thing to a recreational sport | — | ⛔ **undeveloped, and a shame** |
 
 ### 7.2 Territories

--- a/docs/superpowers/specs/2026-07-26-goblinpack-supplement-design.md
+++ b/docs/superpowers/specs/2026-07-26-goblinpack-supplement-design.md
@@ -43,7 +43,7 @@ Skeleton follows v0's table of contents. Status is honest: most of this is not w
 | | Goblinoid Races | ✅ **designed** — six races, real stats, conversion method |
 | | Half Breeds and Mixed Heritage | ✅ **designed** |
 | | Relations with Giant-Kin | ⛔ not started |
-| **Two** | Character Creation | 🟡 races + cultures done; class packages outstanding |
+| **Two** | Character Creation | 🟡 races + cultures done; **CHA re-baseline designed + playtested (§5A)**; class packages outstanding |
 | | Goblinoid Character Classes | 🟡 3 of 8 drafted (§5C): Prevaricator Bard, Wolf Rider, Crafter |
 | | Organizations and Cults | 🟡 10 cults digested; theological politics outstanding |
 | | Equipment and Magic | 🟡 anti-craftsmanship now has a mechanism (§5C.3 *Fast and Filthy*) |
@@ -266,6 +266,36 @@ Native Tongue, and the Experience Modifier.
 
 Applies to CHA only. The other characteristics are differentiated across species and show no sign
 of the same flattening, so there is no evidence to justify extending the treatment.
+
+### The re-baseline in play (sessions 1–3)
+
+The rule was not a paper decision; it was built into Vek's sheet and ran at the table across the
+first three sessions. What play established, for GMs adopting it:
+
+- **The two numbers live on one line.** Vek's CHA is recorded as **12** — his rating *among his own
+  people*. Against a caravan guard, a duke's man, or Sister Ilenne it is **8** (12 − 4). Both are
+  the same characteristic seen from two sides; the sheet carries the 12 and the GM subtracts the 4
+  at the moment of a cross-culture roll. Never write the 8 down as if it were the goblin.
+- **The floor is real, not gifted.** At CHA 12 Vek's **Experience Modifier is still 0** — the `3d6`
+  re-baseline makes the +1 band *reachable* (CHA 13+), it does not hand it over. This matters: the
+  rule repairs a systematic slander (no goblinoid could ever clear the band) without making
+  goblinoids quietly better learners than the numbers earn. A goblinoid who wants the modifier still
+  has to have rolled for it.
+- **Within-culture speech pays full price.** When Vek stood on the rock and shouted the settlement
+  down ("OI!!! GOBBOS!…"), that was an Influence roll *among his own people* — **no penalty**, the
+  full **27** (CHA 12 × 2 = 24, +3 house-ruled from experience). The identical speech aimed at
+  Ilenne or at the duke's emissary would resolve at an effective CHA of 8. **The stage a goblinoid
+  is most persuasive on is the one facing inward** — which is exactly what a boast-singer, an
+  Outrider rallying the line, or a chief holding a warren together actually does.
+- **The penalty is a two-way fact, and the table felt it.** Ilenne, a human cleric dropped into
+  Khorvenn, is as tongue-tied among the gobbos as they are at court — her −4 toward them and theirs
+  toward her are the *same* wall from opposite sides. "Everyone hates us" stops being a passion the
+  players recite and becomes a number that bites in both directions every time an outsider is in the
+  room. This is the mechanical spine under the whole "Wrong Cathedral" premise.
+
+**GM guidance:** carry CHA as the in-culture value, apply −4 the instant a roll crosses the cultural
+line (either direction), and let players feel the difference between rallying their own and
+bargaining with the enemy. That felt gap *is* the supplement.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-26-goblinpack-supplement-design.md
+++ b/docs/superpowers/specs/2026-07-26-goblinpack-supplement-design.md
@@ -38,7 +38,7 @@ Skeleton follows v0's table of contents. Status is honest: most of this is not w
 | Part | Chapter | Status |
 |---|---|---|
 | **One** | Overview & Introduction | ✅ framing + Thekla's voice settled |
-| | Good and Evil for Goblinoids | ✅ **designed** — five virtues, contextual hatred, Evil-is-not-psychopathy |
+| | Good and Evil for Goblinoids | ✅ **designed + playtested** — five virtues, contextual hatred, Evil-is-not-psychopathy; waning record from play (§4.1a) |
 | | Origins and Mythology | ⛔ **seed only** — see §4 |
 | | Goblinoid Races | ✅ **designed** — six races, real stats, conversion method |
 | | Half Breeds and Mixed Heritage | ✅ **designed** |
@@ -102,6 +102,45 @@ Two load-bearing clarifications, both from the user's design notes:
 
 Goblinoids reject the label "evil" as effete elvish propaganda, and given the historical conduct
 of elves and humans toward them, the reader is not obliged to disagree.
+
+### 4.1a The moral psychology in play — the waning record
+
+Playtest lore from the goblinpak campaign (sessions 1–3), now canon. This is the §4.1 design and
+the §5C.2a dosage mechanic producing table results, and it belongs in the supplement as the worked
+example of how Moral Philosophy runs for goblinoid characters.
+
+**Moral Philosophy is a passion, and the Concord erodes it.** CF core: base 30 + POW×2; if reduced
+to 0, a new philosophy replaces it per recent actions. Three data points from Khorvenn, year 8:
+
+| Character | Moral Philosophy | Base | Current | Why |
+|---|---|---|---|---|
+| Drakmoor (chief) | Evil (Heartless and Slaver) | 58 | **39** | Eight years of the dawn ritual — most-dosed resident |
+| Ozmek (Fixer) | Evil (Spiteful) | 52 | **33** | Settlement resident; closest of the Fixers to losing it entirely |
+| Vek (PC, wolf-rider) | Evil (Bloodthirsty and Spiteful) | 54 | **54** | Entirely unwaned — away from the water more than anyone his age |
+
+Rules of the record:
+
+- **Waning is invisible from inside.** Nobody experiences their number dropping. Drakmoor
+  experiences his as *exhaustion*; the outriders experience everyone else's as *going soft*. The
+  least-dosed character in the settlement is mechanically its least civilised — and reads himself
+  as the only one still seeing clearly.
+- **The Evil passion never produces mercy — it produces reclassification.** The played proof: Vek
+  speared an unarmed cleric from behind, then saved her life — not out of pity, but because his
+  wolf sat down beside her and the only category his culture offered for "thing I will now protect"
+  was *property*. Every humane act that followed ("she's ours now", the infirmary, the speech at
+  the cave mouth) came from moving one person from *meat* to *mine*, and he would be insulted to
+  hear it called kindness. The five virtues stayed fully intact throughout. **This is the pattern
+  GMs should run:** under the Concord, goblinoids do not soften their values; they widen the circle
+  of who counts as *ours*, one grudging reclassification at a time.
+- **New passions form as chains of possession.** Vek's passion for the cleric wrote itself as *The
+  Healer Is Mine (And I Am Vosh's)* — attachment expressed as ownership, ownership embedded in a
+  hierarchy of belonging. Goblinoid passions about people should take this shape; "I love X" is an
+  elvish sentence.
+- **Replacement is not redemption, and it is mourned.** When Evil hits 0 it is replaced per recent
+  actions — in the Concord's gravity, with Neutral (still greedy, dishonest, self-centred; no
+  longer cruel or enslaving). A traditionalist would call that a death, and from inside the culture
+  he is not entirely wrong. Ozmek is the settlement's live case: at 33 and falling, closest to the
+  threshold, and nobody — including Ozmek — knows what is coming.
 
 ### 4.2 Seed only: Origins and Mythology
 

--- a/docs/superpowers/specs/2026-07-26-gobtown-origins-design.md
+++ b/docs/superpowers/specs/2026-07-26-gobtown-origins-design.md
@@ -363,13 +363,48 @@ unavailable** to goblinoid races, per the book's own conversion note; use Cleric
 
 ---
 
-## 6. The scenario: "The Emissary"
+## 6. The opening arc
 
-> **Rev. 1 discarded a scenario built on a pilgrim the party had to keep alive to avoid human
-> reprisals. That was wrong.** Goblinoids do not fear retribution and would eat her. The
-> constraint was human prudence smuggled into a goblinoid setting — exactly the failure mode
-> §1's design test exists to catch. The replacement generates its pressure from goblinoid
-> virtues instead.
+> **Rev. 1 built a scenario on a pilgrim the party had to keep alive to avoid human reprisals.
+> That was wrong** — goblinoids do not fear retribution, and the constraint was human prudence
+> smuggled into a goblinoid setting, exactly the failure mode §1's design test exists to catch.
+> The cleric survives as **the cold open**, reframed; the campaign proper begins with Thekla.
+
+### 6.0 Cold open — "The Wrong Cathedral"
+
+**The situation, not the script.** A cleric of Ehrendil Beldroth comes over the pass. She felt a
+manifestation of her god — for her order, the event of a lifetime — and she has walked for months
+toward it, expecting what that promises: a hidden grove, an elven ruin, a choir, a spring in a
+cathedral of light. Something lovely.
+
+She finds a hole in a mountain that smells of wet stone and old meat. Fungus beds. Bones.
+Several dozen goblinoids holding knives and appraising her robe.
+
+**And the presence is still there, undiminished.** That is the joke and the theological crisis in
+one image: her faith has brought her unerringly to a goblin warren and told her it is holy.
+
+**The scene's best beat.** She asks them where it is — in Elvish, then in Common, with rising
+desperation. *They do not understand the question.* They are living on top of the greatest
+manifestation of their age and have no idea, and cannot be made to care. She knows something they
+do not; they hold every card. Neither can use the advantage.
+
+**Her fate is open.** This is a situation, not a scripted killing. Eating her is available and
+entirely in character — but so is ransoming her, hiding her, ignoring her, or (the most
+interesting outcome) **letting her stay**, because a cleric whose god is demonstrably present has
+every theological reason to remain and none to report it. That version puts the only person in
+Gobtown who understands what is actually happening inside the walls, permanently.
+
+**The mechanical reveal.** The Concord does not protect her — she is not a settler. But one or two
+PCs hesitate anyway and cannot say why. That is the players' first evidence that something in the
+water is working on them: this felt faintly wrong, and it never has before. Nobody explains it.
+
+**Unresolved thread — the angel's silence.** It sensed her coming days out and said nothing.
+Whether Drakmoor realises this, whether he was warned and chose, and whether the angel's quiet was
+calculation or cowardice, is deliberately left open here. Settle it in play; it determines whether
+the angel's shift from resentment to warmth reads as affection or as the conduct of someone who
+has already paid for this experiment and cannot walk away.
+
+**Whatever happens becomes the thing that cannot be said** — which is what loads the next scenario.
 
 ### 6.1 The party — the Fixers
 
@@ -382,9 +417,13 @@ Each Fixer needs: race, class, why they fled the Kazhrun, and what they owe Drak
 
 ### 6.2 The situation
 
-**Thekla Morvani walks into Gobtown.** She did not follow a map — a Prevaricator follows tales,
-and a rumour of a chief who makes tribes cooperate was too good to ignore. She came to see
-whether the story is true.
+**Thekla Morvani walks into Gobtown**, days or weeks after the cleric. She did not follow a map —
+a Prevaricator follows tales, and a rumour of a chief who makes tribes cooperate was too good to
+ignore. She came to see whether the story is true.
+
+She arrives into the aftermath of §6.0. Whatever the party did with the cleric is now the best
+story in Gobtown and the one story that must never be told — and a professional collector of
+exactly this kind of material is sitting by the fire, buying drinks.
 
 **Why they cannot simply eat her.** Two reasons, both native to goblinoid culture:
 
@@ -448,7 +487,7 @@ Target: `myth-campaign-f0745885c38a` in `alh_mythras`.
    Morvani (half-orc); Duke Aldric Kessarin; a traditionalist ringleader.
 6. **New factions** — the surviving Ironspear, the traditionalists, Valdenmark, the Kazhrun
    tribes, the mixed-heritage settlers.
-7. **Scenario** — "The Emissary" as gm-visibility lore.
+7. **Scenarios** — "The Wrong Cathedral" (cold open) and "The Emissary" as gm-visibility lore.
 8. **Templates** — spawnable stat blocks for goblin/hobgoblin/orc/bugbear using the real
    Chapter 11 numbers, replacing the invented ones seeded on 2026-07-25.
 

--- a/docs/superpowers/specs/2026-07-26-gobtown-origins-design.md
+++ b/docs/superpowers/specs/2026-07-26-gobtown-origins-design.md
@@ -1,9 +1,12 @@
 # Gobtown: Founding Era — Design Spec
 
-**Date:** 2026-07-26 (rev. 2 — race stats sourced from the rulebook; scenario reworked)
+**Date:** 2026-07-26 (rev. 3 — retargeted to CF core; single-axis alignment)
 **Campaign:** `goblinpak` — `myth-campaign-f0745885c38a` (TypeDB `alh_mythras`)
-**System:** Mythras Classic Fantasy Imperative (CFI)
+**System:** Mythras **Classic Fantasy** (TDM500 core)
 **Status:** Draft for review
+
+> **This is a chapter, not the project.** GoblinPack is a full supplement; Gobtown is one setting
+> inside Part Three. Parent spec: [`2026-07-26-goblinpack-supplement-design.md`](2026-07-26-goblinpack-supplement-design.md)
 
 **Source note.** All race numbers in §5 are transcribed from *Classic Fantasy* (TDM500) Chapter 11,
 extracted from the user's own copy. Full extraction with page/line citations:
@@ -15,7 +18,7 @@ extracted from the user's own copy. Full extraction with page/line citations:
 
 GoblinPack is a Classic Fantasy supplement in which goblinoids are protagonists rather than
 battle-fodder. This spec covers the **founding era** of Gobtown: a settlement roughly eight
-years old, a few hundred souls in a cave network in a remote northern pass, which everyone
+years old: a single large hive of 50-100 goblinoids in a cave network in a remote northern pass, which everyone
 including most of its own residents expects to fail.
 
 The design thesis, from Haidt's moral foundations work: goblinoids are not immoral, they
@@ -111,7 +114,7 @@ notation in an unreadable script. Objects left overnight are found arranged in g
 patterns by morning.
 
 The water carries the harmony through the settlement — drunk, bathed in, irrigating the fungus
-beds. This answers how a hidden cave feeds several hundred people: **it feeds them because the
+beds. This answers how a hidden cave feeds a hundred people at all: **it feeds them because the
 god is in the water.** Cutting the water is cutting the god.
 
 ### 4.2 The four-layer irony
@@ -172,23 +175,15 @@ is the campaign.
 
 ### 5.2 Which rules format to write in
 
-The books contain **two incompatible PC race formats**:
+**Decided: CF core (TDM500), Format 1.** Reversed from rev. 2, which targeted the Imperative SRD.
 
-| | Format 1 — CF core (TDM500 Ch. 2) | Format 2 — CFI SRD (ORC-licensed) |
-|---|---|---|
-| Alignment | Single-axis Moral Philosophy (Good/Neutral/Evil) | **Two-axis: Ethical Code + Moral Code** |
-| Vision trait | Infravision | **Darkvision** |
-| Free Skills line | implicit | **explicit** |
-| Literacy | not addressed in race entry | **explicit Illiterate rule** |
-| NPC stat block | included in race entry | absent |
+The deciding evidence is the supplement's own class list, which contains **Bard** and
+**Thief-Acrobat** — present in CF core, absent from the four-class Imperative. Targeting CFI would
+have silently deleted two of the eight archetypes. See the parent spec §3.
 
-**Decision: write in Format 2 (CFI SRD).** Three reasons — it matches the campaign's CFI setting
-and the 348-piece rules graph already loaded in `alh_mythras`; it carries the two-axis alignment
-the design in §5.7 depends on; and it is **ORC-licensed**, which means goblinoid race write-ups
-built against it are publishable without TDM clearance.
-
-Terminology consequence: creature entries say *Infravision*; PC entries say *Darkvision*. Port
-accordingly.
+Consequences carried through this document: **single-axis Moral Philosophy** rather than two-axis
+alignment (§5.8), **Infravision** rather than Darkvision, and no ORC license. The 348 rule pieces
+loaded in `alh_mythras` are Imperative and now diverge from the target system — see parent spec §9.
 
 ### 5.3 The races (as printed in TDM500 Ch. 11)
 
@@ -354,33 +349,54 @@ are building, and **the first child to come of age with it is a campaign milesto
 their targets are fellow settlers, because the Concord has quietly redrawn who is fair game.
 Players will notice their passions sliding and will not be told why.
 
-### 5.8 The alignment rider
+### 5.8 The alignment rider — and why it is not a house rule
 
-Goblinoid PCs are Evil. The Concord does not make anyone Good — it **redraws the boundary of who
-counts as fair game** to include fellow settlers.
+In CF core, **Moral Philosophy** is a single axis (Good / Neutral / Evil) plus one or two defining
+traits, starting at **30% + POW×2**, and it is the *first Passion every character has*. The core
+book then supplies this rule verbatim:
 
-A Gobtown goblin is still Evil by any Valdenmark cleric's reckoning: cruel to outsiders,
-contemptuous of weakness, delighted by others' misfortune. He simply does not rob his neighbours
-any more, and **could not tell you why not.** That is the angel's work expressed as an alignment
-rule, and it is the most important mechanical statement in this document.
+> "if the chosen philosophy is reduced to 0, then a new one replaces it at base level, per the
+> character's recent actions."
 
-The SRD's Evil trait list (Abusive, Cruel, Domineering, Enjoys Harming Innocents, Hates Good,
-Merciless, Sadistic, Slaver, Spiteful) is used unchanged. Only the *target set* narrows.
+**That is the Concord, already written.** No house rule is required. The angel's influence causes a
+settler's Evil to wane; at zero it is *replaced* according to recent conduct — which in Gobtown
+means **Neutral**. And CF's Neutral is exactly the target state: "the same compunctions against
+killing innocent creatures that a Good character would have, but lack the commitment to make
+sacrifices to protect or help others." Still Greedy, Dishonest, Self-centred, Vain. No longer
+Cruel, Slaver, Cannibalistic.
 
-Ethical axis drifts Lawful under the Concord. Drakmoor is Lawful Evil and drifting further —
-which he experiences as exhaustion.
+**Civilisation without redemption.** Nobody in Gobtown is being made good. They are being made
+*ordinary*, which is stranger and far more unsettling — and Ghazrek is correct to regard it as a
+death. He has watched people he bled beside stop being themselves, and the only person who could
+explain why performs a private ritual at dawn and will not say what it is.
+
+Evil traits available (core Passions Table): Betrayer, Bloodthirsty, Cannibalistic, Chaotic, Cruel,
+Hateful, Heartless, Murderous, Sadistic, Slaver, Spiteful, Wicked. Neutral traits: Conceited,
+Dishonest, Egotistic, Greedy, Independent, Lack of morality, Pompous, Self-centred, Vain,
+Well balanced.
+
+**Read the roster's Moral Philosophy column as a progress bar.** Ghazrek 62 and rising; Vharza 44;
+Ozmek 33 and nearly gone. Drakmoor 39, against a base of 58 — eight years of dawn meditation, and
+he has no idea it is happening to him.
 
 ### 5.9 Classes
 
-| CFI class | Goblinoid expressions |
-|---|---|
-| Fighter | warrior, wolf-rider, beast handler, pit-fighter |
-| Rogue | sneak, agent, hunter, scout, acrobat |
-| Cleric | priest, shaman, Prevaricator (Vykthar) |
-| Magic-User | hedge-wizard, alchemist, ritualist |
+Full CF class list applies. See parent spec §5 for the mapping and the two new classes
+(**Wolf Rider** and **Merchant / Crafter / Miner**).
 
-Merchant/crafter/miner concepts are Professional skill loadouts, not classes. **Druid is
-unavailable** to goblinoid races, per the book's own conversion note; use Cleric.
+| CF class | Goblinoid expressions |
+|---|---|
+| Fighter | warrior, pit-fighter, chief's fist |
+| Thief | sneak, agent, hunter, scout |
+| Thief-Acrobat | tunnel-runner, roof-work |
+| Cleric | priest, shaman, Prevaricator (Vykthar — pending, parent §5.2) |
+| Magic-User | hedge-wizard, alchemist, ritualist |
+| Bard | entertainer, jester, boast-singer |
+| **Wolf Rider** 🆕 | beast handler — *a Kazhrun class, near-useless in Khorvenn's tunnels* |
+| **Crafter / Miner** 🆕 | *the Gobtown class; barely exists in the tribal lands* |
+
+**Closed to goblinoids:** Paladin (Lawful Good unreachable) and Druid, per the book's own note;
+use Cleric.
 
 **Restriction:** no PC may be a cleric of Ehrendil Beldroth. Obviously.
 
@@ -518,8 +534,11 @@ Target: `myth-campaign-f0745885c38a` in `alh_mythras`.
 
 ## 8. Open questions
 
-1. **Population ceiling.** Prior instinct was 300–400 for a settlement that must stay hidden;
-   remoteness argues for the low end. Needs a number before "The Emissary" is run.
+1. ~~**Population ceiling.**~~ **Resolved: 50-100 total.** A single large hive, not a town. At
+   this scale everyone knows everyone, Thekla can plausibly speak to the *entire settlement* in a
+   week, and they sit right at the 80-inhabitant mark Drakmoor himself identified as the point of
+   no return. Every trade is one or two people deep: if the only competent stone-cutter dies, the
+   tunnels stop. This is a scenario generator, not just a number.
 2. **Who carved Khorvenn?** The caves predate Drakmoor. Either Ehrendil placed the spirit in
    anticipation, or it is a much older site repurposed — the second is more interesting and asks
    who cut the musical notation into the walls.

--- a/docs/superpowers/specs/2026-07-26-gobtown-origins-design.md
+++ b/docs/superpowers/specs/2026-07-26-gobtown-origins-design.md
@@ -1,9 +1,13 @@
 # Gobtown: Founding Era — Design Spec
 
-**Date:** 2026-07-26
+**Date:** 2026-07-26 (rev. 2 — race stats sourced from the rulebook; scenario reworked)
 **Campaign:** `goblinpak` — `myth-campaign-f0745885c38a` (TypeDB `alh_mythras`)
 **System:** Mythras Classic Fantasy Imperative (CFI)
 **Status:** Draft for review
+
+**Source note.** All race numbers in §5 are transcribed from *Classic Fantasy* (TDM500) Chapter 11,
+extracted from the user's own copy. Full extraction with page/line citations:
+`scratchpad/cf/EXTRACT.md`. No Greymyr manuscript material was read (see §2).
 
 ---
 
@@ -24,42 +28,42 @@ How hate-filled a group is depends on leadership, scarcity, and history — not 
 
 **The Evil passion is not psychopathy.** Pre-modern humans enjoyed public executions without
 being unable to love their children. Cruelty is a spectator taste and a tool, directed by
-cultural rules about who is fair game. This distinction is load-bearing; see §5.5.
+cultural rules about who is fair game. This distinction is load-bearing; see §5.7.
+
+**Design test for every rule in this document:** does the pressure come from goblinoid values,
+or from human ones smuggled in? The first draft of the opening scenario failed this test (§6).
 
 ### Scope boundary
 
-This spec covers the founding era only. The present-day Year 12 material already in the
-database (the full city, the Accords, the inner circle) is retained as GM-visibility
-*future canon* — it tells the GM what is at stake, and is not playable content here.
+Founding era only. The Year 12 material already in the database (the full city, the Accords,
+the inner circle) is retained as GM-visibility *future canon* — it tells the GM what is at
+stake, and is not playable content here.
 
 ---
 
 ## 2. Canon boundaries
 
-Greymyr setting material is under NDA and has **not** been read. Nothing in this spec derives
-from it. The proxy policy:
+Greymyr setting material is under NDA and has **not** been read. Nothing here derives from it.
 
-| Keep (published TDM pantheon / user's own work) | Proxy (Greymyr gazetteer) |
+| Keep (published TDM / user's own work) | Proxy (Greymyr gazetteer) |
 |---|---|
 | Ehrendil Beldroth — elven god of music and creation | the mountain range |
 | Garex Blood-Drinker, Grumash, Thaogg Axefang, Zulfang | the human realm |
 | The user's cults: Vykthar, Velthara, Grottendacz, Mawhunger Gnawbone, Khorthak, Sniktch, Razak, Skarrak | the duke |
 | Drakmoor, the Ironspear Clan, Thekla Morvani, Gobtown | any named site from the manuscripts |
 
-**Coined proxy names** (cheap to change; all follow the stated rule that descriptive elements
-should be titles rather than surnames):
+**Coined proxy names** (provisional; cheap to change):
 
-- **The Kazhrun** — the mountain spine east of human lands; goblinoid heartland, permanently
-  at war with itself, no institution outliving the chief who founded it. Humans call it the
-  Eastern Wall.
-- **The Duchy of Valdenmark** — the human realm to the west. Wealthy, hostile to goblinoids,
-  under low-grade pressure from Kazhrun raiding.
+- **The Kazhrun** — the mountain spine east of human lands; goblinoid heartland, permanently at
+  war with itself. Humans call it the Eastern Wall.
+- **The Duchy of Valdenmark** — the human realm to the west. Wealthy, hostile, under low-grade
+  pressure from Kazhrun raiding.
 - **Duke Aldric Kessarin** — its ruler; advised on goblinoid matters by Thekla Morvani.
 - **Khorvenn**, *the humming* — the cave system Gobtown grows inside.
 
-Location is deliberately loose: a high pass at the cold northern end of the Kazhrun, outside
-the tribal lands, reachable only by routes that kill the careless. **Remoteness is the city's
-first wall** and the reason a secret this large can be kept at all.
+Location is deliberately loose: a high pass at the cold northern end of the Kazhrun, outside the
+tribal lands, reachable only by routes that kill the careless. **Remoteness is the city's first
+wall**, and the reason a secret this large can be kept.
 
 ---
 
@@ -68,23 +72,30 @@ first wall** and the reason a secret this large can be kept at all.
 Thekla Morvani, Grand Prevaricator of Vykthar, advisor on goblinoid matters to Duke Aldric
 Kessarin, narrates the supplement. Each chapter is framed by her commentary.
 
-A Grand Prevaricator is a professional myth-maker. This makes the narrator **unreliable by
+A Grand Prevaricator is a professional myth-maker, which makes the narrator **unreliable by
 doctrine**: she is not neutrally describing goblinoid society, she is selling it to a hostile
-human court, and every framing is an act of advocacy by a priestess whose goddess rewards the
-tale told well.
+human court. Every framing is advocacy by a priestess whose goddess rewards the tale told well.
 
-**Thekla does not know about the Wellspring.** (Decided 2026-07-26.) Her narration is honest
-as far as it goes; she is arguing for goblinoid complexity from evidence, not protecting a
-secret. Her eventual discovery of what actually underwrites Gobtown is therefore a real event
-with real consequences for her position, her faith, and her patron.
+**Thekla does not know about the Wellspring.** Her narration is honest as far as it goes; she
+argues for goblinoid complexity from evidence, not to protect a secret. Her eventual discovery
+of what actually underwrites Gobtown is a real event.
+
+**Race:** half-orc. This matches Vykthar's own iconography (the goddess appears as a half-orc of
+indiscernible mixture) and makes Thekla the road not taken for every mixed-heritage settler in
+Gobtown — a half-breed who found status in a human court because no goblinoid clan would have
+her. See §5.4.
+
+**Title reconciliation:** the cult's internal ranks are Scarkeeper, Warsinger, Braggard, and
+Listener. "Grand Prevaricator" is the formal title she uses at court, because "Warsinger" would
+not survive a Valdenmark audience chamber.
 
 Her established voice, from the v0 draft:
 
-> "Your Grace — it might be wiser to stop thinking of your adversaries in the mountains as
-> just chaotic and 'evil.' It is true that they want nothing more in life than to wade
-> through the blood of your countrymen... But you must also remember that the only reason
-> they would contemplate these actions is that it would make a fantastic drinking song.
-> Please… at least try to see it from their point of view."
+> "Your Grace — it might be wiser to stop thinking of your adversaries in the mountains as just
+> chaotic and 'evil.' It is true that they want nothing more in life than to wade through the
+> blood of your countrymen... But you must also remember that the only reason they would
+> contemplate these actions is that it would make a fantastic drinking song. Please… at least
+> try to see it from their point of view."
 
 ---
 
@@ -92,16 +103,16 @@ Her established voice, from the v0 draft:
 
 ### 4.1 What it is
 
-In the deepest chamber of Khorvenn, a natural cathedral of stone holds a pool that sings.
-Bound in chains of crystallised song is an angelic spirit of Ehrendil Beldroth — and the
-spring and the spirit are **one entity, two aspects**. The water is the angel's presence made
-physical. Ancient carvings cover the approach: spiralling patterns that shift in torchlight,
-musical notation in an unreadable script. Objects left overnight are found arranged in
-geometric patterns by morning.
+In the deepest chamber of Khorvenn, a natural cathedral of stone holds a pool that sings. Bound
+in chains of crystallised song is an angelic spirit of Ehrendil Beldroth — and the spring and
+the spirit are **one entity, two aspects**. The water is the angel's presence made physical.
+Ancient carvings cover the approach: spiralling patterns that shift in torchlight, musical
+notation in an unreadable script. Objects left overnight are found arranged in geometric
+patterns by morning.
 
 The water carries the harmony through the settlement — drunk, bathed in, irrigating the fungus
-beds. This answers the standing question of how a hidden cave feeds several hundred people:
-**it feeds them because the god is in the water.** Cutting the water is cutting the god.
+beds. This answers how a hidden cave feeds several hundred people: **it feeds them because the
+god is in the water.** Cutting the water is cutting the god.
 
 ### 4.2 The four-layer irony
 
@@ -112,38 +123,38 @@ beds. This answers the standing question of how a hidden cave feeds several hund
 | Ehrendil Beldroth | Goblinoids are part of creation and currently outside the Song. They cannot be commanded into harmony without destroying what makes them themselves. So they must be brought in through their own cunning and self-interest — offered civilisation as a prize they think they stole. |
 | Everyone else | Will be horrified on discovery, and will not understand what they are looking at. |
 
-The binding ritual is theatre. It is also a daily meditation that gradually attunes Drakmoor
-to reciprocity, deferred gratification, and mutual benefit. The angel's grudging advice
+The binding ritual is theatre. It is also a daily meditation that gradually attunes Drakmoor to
+reciprocity, deferred gratification, and mutual benefit. The angel's grudging advice
 consistently steers him toward solutions that strengthen the community rather than his grip.
 
 ### 4.3 The Concord (mechanics)
 
-The harmony has a real mechanical footprint. Within Gobtown:
+Within Gobtown:
 
 - Cooperative actions (assisting, coordinated effort, shared labour) gain an **augment**.
 - Inter-species friction checks run **one difficulty grade easier**.
-- Passions pulling toward communal benefit **deepen** faster than normal; passions pulling
-  toward predation on fellow settlers **wane** faster. (Uses `cfi/alignment/deepening-waning`.)
+- Passions pulling toward communal benefit **deepen** faster; passions pulling toward predation
+  on fellow settlers **wane** faster (uses `cfi/alignment/deepening-waning`).
 
-**The decay clock.** If the dawn ritual is missed, the Concord degrades visibly:
+**The decay clock.** If the dawn ritual is missed:
 
 | Elapsed | Effect |
 |---|---|
 | Day 1 | Augment lost. Bickering, old grudges resurface. |
 | Day 2 | Friction checks return to normal grade. Hoarding begins; shared stores are raided. |
 | Day 3 | Friction checks one grade *harder* than baseline. Knives. |
-| Day 4+ | The settlement begins to disassemble along tribal lines. |
+| Day 4+ | The settlement disassembles along tribal lines. |
 
-This makes "keep the chief alive and on schedule" a live playable pressure, and lets players
-feel the divine presence through their own dice long before anyone explains it.
+Players feel the divine presence through their own dice long before anyone explains it.
 
 ### 4.4 Discovery vectors
 
 - A cleric of Ehrendil senses **one** presence, unmistakably, at considerable range.
 - The water tastes wrong to anyone who has drunk from a real spring.
 - Anyone who follows wet stone downhill far enough arrives.
-- **Koolinth can enter the pool.** They are the only settlers who can physically swim in the
-  god. This is a standing risk and a standing story opportunity — see §5.2.
+- **Koolinth can enter the pool** (§5.3). They are the only settlers who can physically swim in
+  the god — a standing risk and a standing story opportunity.
+- **Someone brags.** This is the likeliest vector by a wide margin, and it drives §6.
 
 ---
 
@@ -151,183 +162,272 @@ feel the divine presence through their own dice long before anyone explains it.
 
 ### 5.1 The structural key: Race vs Culture
 
-CFI Step 5 separates **Race** (physiology: characteristic dice, darkvision, movement,
-lifespan) from **Culture** (skill package, alignment, passions — what you were raised into).
+CFI separates **Race** (physiology: characteristic dice, darkvision, movement, lifespan) from
+**Culture** (skill package, alignment, passions — what you were raised into).
 
 In year eight, **Gobtown culture does not exist yet.** Every adult in the caves was raised in
-the Kazhrun. Every PC therefore arrives with tribal skills, tribal passions, and tribal
-instincts about who is fair game — all wrong for the place they now live. The friction between
-what the character was raised to be and what the settlement needs is not colour text; it is
-on the sheet, and it is the campaign.
+the Kazhrun, so every PC arrives with tribal skills, tribal passions, and tribal instincts about
+who is fair game — all wrong for the place they now live. That friction is on the sheet, and it
+is the campaign.
 
-Two culture packages are written. Only one is available.
+### 5.2 Which rules format to write in
 
-### 5.2 Races
+The books contain **two incompatible PC race formats**:
 
-Characteristic dice follow the CFI Racial Characteristics Table format. Averages in
-parentheses are used for Points Build.
+| | Format 1 — CF core (TDM500 Ch. 2) | Format 2 — CFI SRD (ORC-licensed) |
+|---|---|---|
+| Alignment | Single-axis Moral Philosophy (Good/Neutral/Evil) | **Two-axis: Ethical Code + Moral Code** |
+| Vision trait | Infravision | **Darkvision** |
+| Free Skills line | implicit | **explicit** |
+| Literacy | not addressed in race entry | **explicit Illiterate rule** |
+| NPC stat block | included in race entry | absent |
 
-| Stat | Goblin | Hobgoblin | Orc | Bugbear | Koolinth | Orog |
-|:--|:--:|:--:|:--:|:--:|:--:|:--:|
-| STR | 2d6+1 (8) | 2d6+6 (13) | 2d6+8 (15) | 2d6+12 (19) | 2d6+5 (12) | 2d6+9 (16) |
-| CON | 3d6 (11) | 2d6+6 (13) | 2d6+6 (13) | 2d6+7 (14) | 2d6+7 (14) | 2d6+8 (15) |
-| SIZ | 1d4+5 (8) | 2d6+6 (13) | 2d6+6 (13) | 2d6+14 (21) | 2d6+5 (12) | 2d6+7 (14) |
-| DEX | 2d6+7 (14) | 3d6 (11) | 3d6 (11) | 3d6 (11) | 2d6+5 (12) | 3d6 (11) |
-| INT | 2d6+5 (12) | 2d6+6 (13) | 2d6+4 (11) | 2d6+3 (10) | 2d6+5 (12) | 2d6+6 (13) |
-| POW | 3d6 (11) | 3d6 (11) | 3d6 (11) | 3d6 (11) | 3d6 (11) | 3d6 (11) |
-| CHA | 2d6 (7) | 2d6+3 (10) | 2d6+1 (8) | 2d6+1 (8) | 2d6+2 (9) | 2d6+2 (9) |
+**Decision: write in Format 2 (CFI SRD).** Three reasons — it matches the campaign's CFI setting
+and the 348-piece rules graph already loaded in `alh_mythras`; it carries the two-axis alignment
+the design in §5.7 depends on; and it is **ORC-licensed**, which means goblinoid race write-ups
+built against it are publishable without TDM clearance.
 
-**Common to all goblinoids:** Darkvision 60 ft (as CFI Half-Orc). Illiterate unless raised in
-a literate culture. Additional languages limited to goblin, hobgoblin, orc, and gnoll.
+Terminology consequence: creature entries say *Infravision*; PC entries say *Darkvision*. Port
+accordingly.
 
-**Per-race special rules:**
+### 5.3 The races (as printed in TDM500 Ch. 11)
 
-- **Goblin** — Movement 20 ft. *Light sensitivity*: Perception and ranged attacks one grade
-  harder in full daylight. Lifespan ~50. Most likely of all goblinoids to be literate; a
-  Goblin may take literacy at creation without the Experience Roll cost.
-- **Hobgoblin** — Movement 25 ft. *Thick hide*: natural 1 AP on all locations. **No light
-  sensitivity.** Lifespan ~60. Natural officers; other goblinoids expect them to command.
-- **Orc** — Movement 25 ft. Light sensitivity as Goblin. Lifespan ~40 — the shortest, and it
-  shapes the psychology: an orc of thirty is old and knows it.
-- **Bugbear** — Movement 25 ft. **No light sensitivity.** *Scent*: Perception by smell one
-  grade easier. Their SIZ makes some cave galleries impassable — a real constraint in Khorvenn
-  and a running joke.
-- **Koolinth** — Movement 20 ft land / 30 ft swim. *Amphibious*: breathes water indefinitely;
-  Swim base doubled. Suffers in dry heat (Endurance one grade harder). **Can enter the
-  Wellspring pool.** In a settlement built on a sacred spring this is enormous: a Koolinth PC
-  can go where Drakmoor cannot follow.
-- **Orog** — Movement 25 ft. *Thick hide*: natural 1 AP. Darkvision 90 ft (deep-dwelling), but
-  light sensitivity is **severe** — two grades harder in full daylight. Disciplined and
-  markedly smarter than common orcs, which common orcs resent.
+Characteristics transcribed verbatim from the creature entries. **These replace the invented
+table in rev. 1 entirely.**
 
-### 5.3 Half-breeds and mixed heritage
+| Stat | Goblin | Hobgoblin | Orc | Bugbear |
+|:--|:--:|:--:|:--:|:--:|
+| STR | 1d6+4 (8) | 2d6+6 (13) | 2d6+7 (14) | 2d6+12 (19) |
+| CON | 3d6 (11) | 3d6+3 (14) | 3d6+2 (13) | 2d6+8 (15) |
+| SIZ | 1d6+4 (8) | 1d6+13 (17) | 2d6+7 (14) | 2d6+14 (21) |
+| DEX | 4d6 (14) | 3d6 (11) | 3d6 (11) | 3d6 (11) |
+| INT | 2d6+5 (12) | 2d6+6 (13) | 2d6+4 (11) | 2d6+3 (10) |
+| POW | 3d6 (11) | 3d6 (11) | 3d6 (11) | 3d6 (11) |
+| CHA | 2d6 (7) | 2d6 (7) | 2d6 (7) | 2d6 (7) |
+| Damage Mod | −1d2 | +1d2 | +1d2 | +1d6 |
+| Movement | 15 ft | 15 ft | 20 ft | 15 ft |
+| Lifespan | ~50 yrs | ~60 yrs | ~40 yrs | not given |
+| Traits | Darkvision, **Light Sensitive** | Darkvision, **Tunnel Sense** | Darkvision, **Light Sensitive** | Darkvision |
 
-Orcs, per the source material, "will breed with anything," and half-breeds are common
-throughout the Kazhrun. Crucially: **a half-breed belongs to no clan.** In tribal society this
-is a permanent disqualification from status, protection, and inheritance.
+Every goblinoid shares POW `3d6 (11)` and CHA `2d6 (7)`. Magic Points 11 across the board.
 
-Which is exactly why they came. The people with no tribe are the first to arrive at a place
-that does not ask what tribe you are from. **Mixed-heritage characters are a disproportionate
-share of founding-era Gobtown, and are a large part of why the settlement cohered at all.**
-This is the historical root of the Mixed District that dominates the Year 12 city.
+**Variants, written as deltas exactly as the book writes them:**
 
-- **Half-Orc** — use the CFI Half-Orc entry as printed. Add the Gobtown note: a half-orc raised
-  among orcs takes the Kazhrun Tribal culture below rather than a human culture.
-- **Goblinoid mixed heritage** (orc×goblin, hobgoblin×orc, bugbear×hobgoblin, etc.) — choose
-  two parent races. For each characteristic, average the two parents' **table averages**
-  (rounding down) and express the result as `2d6+N` where N = average − 7; if that average is
-  7 or less, use `2d6`. Working from the averages rather than the dice expressions avoids the
-  problem that parents may roll different dice entirely (Goblin SIZ is `1d4+5`, Orc SIZ is
-  `2d6+6`). *Example — Orc × Goblin:* STR (15+8)/2 = 11 → `2d6+4`; SIZ (13+8)/2 = 10 →
-  `2d6+3`. Take darkvision from the better parent, light sensitivity from the worse, and
-  movement from the smaller. Choose one parent's special rule; the other is lost.
-- **Passion, all mixed heritage:** *No Clan Will Have Me* — starts at the standard passion
-  value. It augments any roll to survive alone, endure contempt, or make common cause with
-  another outcast. In Gobtown, and only in Gobtown, it begins to wane.
+- **Koolinth** — sub-species of **Hobgoblin**. Inherits everything; overrides colouration and
+  language, Combat Style becomes spears/tridents/pikes, and adds the **Aquatic** and **Swimmer**
+  traits, Swim 66%, and 20 ft underwater movement. *A Koolinth PC is mechanically a hobgoblin
+  who can swim into the Wellspring.*
+- **Orog** — variant of **Orc** ("great orcs", 6–6½ ft, possibly part ogre). Overrides STR
+  `2d6+10`, CON `3d6+6`, SIZ `1d6+12`, DEX `2d6+2` (**the book prints no averages for these — do
+  not compute them into the Points Build column without flagging**); +10% to Athletics, Brawn,
+  Endurance, Unarmed and Combat Style; 2 points of tough skin. "Treated in all other ways as
+  orcs." Rare — roughly one per ten orc warriors.
 
-### 5.4 Culture packages
+### 5.4 Half-breeds and mixed heritage
+
+Orcs "will breed with anything," and half-breeds are common throughout the Kazhrun. Crucially,
+**a half-breed belongs to no clan** — a permanent disqualification from status, protection, and
+inheritance in tribal society.
+
+Which is exactly why they came. The people with no tribe are the first to arrive at a place that
+does not ask what tribe you are from. **Mixed-heritage characters are a disproportionate share
+of founding-era Gobtown and a large part of why the settlement cohered at all** — the historical
+root of the Mixed District that dominates the Year 12 city.
+
+- **Half-Orc** — use the SRD entry **as printed** (`cfi_srd.txt` p. 21–22). It is the only
+  playable goblinoid-descended race in the books and needs no conversion. Gobtown rider: a
+  half-orc raised among orcs takes Kazhrun Tribal culture (§5.6) rather than a human culture.
+- **Goblinoid mixed heritage** (orc×goblin, hobgoblin×orc, bugbear×hobgoblin…) — choose two
+  parent races. For each characteristic, average the two parents' **printed averages** (rounding
+  down) and express as `2d6+N` where N = average − 7; if the average is 7 or less, use `2d6`.
+  Work from averages, not dice expressions, because parents often roll different dice entirely
+  (Goblin SIZ is `1d6+4`, Orc SIZ is `2d6+7`). *Example — Orc × Goblin:* STR (14+8)/2 = 11 →
+  `2d6+4`; SIZ (14+8)/2 = 11 → `2d6+4`. Take Darkvision from the better parent, Light Sensitive
+  from the worse, movement from the smaller. Choose one parent's special trait; the other is lost.
+- **Passion, all mixed heritage:** *No Clan Will Have Me*, at the standard starting value. It
+  augments any roll to survive alone, endure contempt, or make common cause with another outcast.
+  In Gobtown, and only in Gobtown, it begins to wane.
+
+### 5.5 Conversion methodology (creature entry → PC race)
+
+**No monster-PC subsystem exists in any of the four books** — no level adjustment, no racial hit
+dice, no procedure. What exists is permission, in TDM500's "Human vs. Non-Human Races":
+
+> "…it is possible to play just about any sapient race in Classic Fantasy, because all creatures,
+> regardless of type, are defined in a consistent and compatible way. As such, Chapter 11:
+> Monsters! offers a number of other possibilities for challenging character concepts."
+
+Permission without procedure. **Defining that procedure is GoblinPack's central mechanical
+contribution.** The method below is recovered empirically from Orc → Half-Orc, the one species
+the books stat in both formats.
+
+| PC-race field | Source in the creature entry |
+|---|---|
+| Characteristic dice | Copy the seven dice + averages verbatim |
+| Starting age | Derive from prose lifespan (orc ~40 → half-orc 14+1d4) |
+| Movement | Copy from the creature's Movement line |
+| Free Skills | Customs +40, Native Tongue +40, Language (Common) +40 |
+| Standard Skills | Six fixed + one "choose one of", drawn from the creature's Skills list |
+| Professional Skills | Authored from the creature's role; orc list is the model |
+| Language limits | From the creature's `Languages (...)` entry |
+| Alignment / Passions | Creature's Passions become the *typical* alignment; add the Loyalty/Love/Hate triplet |
+| Special Rules | Creature's `Abilities:` line → bulleted talents, **Movement always first** |
+| Average Lair / Treasure | Dropped — becomes N/A with a footnote |
+| Classes | Authored. Note: "most monster races cannot be Druids"; use Cleric |
+
+**Two deliberate departures from the Half-Orc precedent**, both flagged as design choices rather
+than oversights:
+
+1. **Keep Light Sensitive.** The book strips it when making the playable Half-Orc ("unlike their
+   orcish parent, half-orcs do not suffer light sensitivity") — but half-orcs have human blood
+   and pure goblinoids do not. More importantly, in this campaign the trait is *load-bearing
+   worldbuilding*: light sensitivity costs a goblin nothing underground and everything above it.
+   **It is a large part of why Gobtown is a cave city at all**, and removing it would erase that.
+2. **Do not inflate INT and CHA.** The book nudged both up by 1 going Orc → Half-Orc. We keep the
+   creature numbers as printed. The premise of the supplement is that goblinoids are interesting
+   as they are; buffing them toward human averages to make them "playable" contradicts the thesis,
+   and the dice ranges already permit an exceptional individual.
+
+**Supporting evidence that goblinoid PCs are intended:** the Cosmology chapter writes cleric
+prerequisites as *"must be goblin or hobgoblin"* (Garex Blood-Drinker) and *"must be orc or
+half-orc"* (Thaogg Axefang), in the identical format used for dwarf and halfling deities. The
+book already assumes these characters exist; it simply never wrote them up.
+
+### 5.6 Culture packages
 
 **Kazhrun Tribal** *(available — this is what everyone has)*
 
-- Free skills: Customs (Kazhrun) +40, Native Tongue +40
+- Free Skills: Customs (Kazhrun) +40, Native Tongue +40
 - Standard: Athletics, Brawn, Endurance, Evade, Perception, Stealth, plus one of Ride or Swim
 - Professional: Craft (any), Intimidation, Survival, Track, plus one of Healing or Navigate
-- Illiterate. Passions from the tribal menu (§5.5). Alignment typically Chaotic Evil;
-  hobgoblins and orogs typically Lawful Evil.
+- Illiterate (per the SRD rule: 1 Experience Roll + 1 month for half-skill literacy)
+- Additional languages limited to goblin, hobgoblin, orc, gnoll
+- Passions from the tribal menu (§5.7). Alignment typically Chaotic Evil; hobgoblins and orogs
+  typically Lawful Evil.
 
 **Gobtown-Born** *(written, but NOT available at character creation)*
 
-Requires being raised in the settlement from early childhood. In year eight the oldest
-qualifying child is seven years old. No PC can take this package. It is printed so players can
-read the future they are building, and **the first child to come of age with it is a campaign
-milestone.**
+Requires being raised in the settlement from early childhood. In year eight the oldest qualifying
+child is seven. No PC can take this package. It is printed so players can read the future they
+are building, and **the first child to come of age with it is a campaign milestone.**
 
-- Free skills: Customs (Gobtown) +40, Native Tongue +40, Language (one other goblinoid) +40
+- Free Skills: Customs (Gobtown) +40, Native Tongue +40, Language (one other goblinoid) +40
 - Standard: Athletics, Deceit, Endurance, Influence, Insight, Locale, Perception
 - Professional: Commerce, Craft (any), Engineering, Lore (any), Streetwise
-- **Literate.** Passions drawn from a different menu entirely: *This Place Must Not Fail*,
-  *My Neighbour Is Not Meat*, *I Have Never Seen The Sky And I Am Fine*.
+- **Literate.** Passions from a different menu entirely: *This Place Must Not Fail*, *My
+  Neighbour Is Not Meat*, *I Have Never Seen The Sky And I Am Fine*.
 
-### 5.5 Passions — the five virtues
-
-The five goblinoid virtues become the standard tribal passion menu. Starting values per
-`cfi/alignment/passion-table`. Each augments rolls taken in accordance with it.
+### 5.7 Passions — the five virtues
 
 | Passion | Augments |
 |---|---|
-| *Shut Up And Get On With It* | Enduring hardship without complaint; completing a task under pressure; refusing to be delayed by ceremony, rank, or feelings |
+| *Shut Up And Get On With It* | Enduring hardship without complaint; completing a task under pressure; refusing delay for ceremony, rank, or feelings |
 | *Be The Biggest Bastard You Can* | Intimidation; claiming credit; any act that deters future challenges |
-| *Extra Points For Comedy Value* | Any action that is both effective and humiliating to the target; improvised cruelty with an audience |
-| *Don't Be A Picky Eater* | Resisting disgust, poison, spoiled food, or starvation; making use of what others discard |
+| *Extra Points For Comedy Value* | Any action both effective and humiliating to its target; improvised cruelty with an audience |
+| *Don't Be A Picky Eater* | Resisting disgust, poison, spoiled food, starvation; using what others discard |
 | *Everyone Hates Us* | Acting against the smug and self-declared righteous; resisting Influence from other races |
 
-**The Concord's effect:** *Be The Biggest Bastard* and *Extra Points For Comedy Value* wane
-when their targets are fellow settlers, because the Concord has quietly redrawn who is fair
-game. Players will notice their passions sliding and will not be told why.
+**The Concord's effect:** *Be The Biggest Bastard* and *Extra Points For Comedy Value* wane when
+their targets are fellow settlers, because the Concord has quietly redrawn who is fair game.
+Players will notice their passions sliding and will not be told why.
 
-### 5.6 The alignment rider
+### 5.8 The alignment rider
 
-Goblinoid PCs are Evil. The Concord does not make anyone Good — it **redraws the boundary of
-who counts as fair game** to include fellow settlers.
+Goblinoid PCs are Evil. The Concord does not make anyone Good — it **redraws the boundary of who
+counts as fair game** to include fellow settlers.
 
 A Gobtown goblin is still Evil by any Valdenmark cleric's reckoning: cruel to outsiders,
-contemptuous of weakness, delighted by others' misfortune. He simply does not rob his
-neighbours any more, and **could not tell you why not.** That is the angel's work expressed as
-an alignment rule, and it is the single most important mechanical statement in this document.
+contemptuous of weakness, delighted by others' misfortune. He simply does not rob his neighbours
+any more, and **could not tell you why not.** That is the angel's work expressed as an alignment
+rule, and it is the most important mechanical statement in this document.
+
+The SRD's Evil trait list (Abusive, Cruel, Domineering, Enjoys Harming Innocents, Hates Good,
+Merciless, Sadistic, Slaver, Spiteful) is used unchanged. Only the *target set* narrows.
 
 Ethical axis drifts Lawful under the Concord. Drakmoor is Lawful Evil and drifting further —
 which he experiences as exhaustion.
 
-### 5.7 Classes
-
-CFI's four classes carry the v0 concept list as goblinoid re-skins:
+### 5.9 Classes
 
 | CFI class | Goblinoid expressions |
 |---|---|
 | Fighter | warrior, wolf-rider, beast handler, pit-fighter |
 | Rogue | sneak, agent, hunter, scout, acrobat |
-| Cleric | priest, shaman, prevaricator (Vykthar) |
+| Cleric | priest, shaman, Prevaricator (Vykthar) |
 | Magic-User | hedge-wizard, alchemist, ritualist |
 
-Merchant/crafter/miner concepts are Professional skill loadouts, not separate classes.
+Merchant/crafter/miner concepts are Professional skill loadouts, not classes. **Druid is
+unavailable** to goblinoid races, per the book's own conversion note; use Cleric.
 
 **Restriction:** no PC may be a cleric of Ehrendil Beldroth. Obviously.
 
 ---
 
-## 6. The scenario: "The Pilgrim"
+## 6. The scenario: "The Emissary"
+
+> **Rev. 1 discarded a scenario built on a pilgrim the party had to keep alive to avoid human
+> reprisals. That was wrong.** Goblinoids do not fear retribution and would eat her. The
+> constraint was human prudence smuggled into a goblinoid setting — exactly the failure mode
+> §1's design test exists to catch. The replacement generates its pressure from goblinoid
+> virtues instead.
 
 ### 6.1 The party — the Fixers
 
 PCs are trusted early settlers, Drakmoor's problem-solvers, **deliberately kept ignorant.**
-Orders arrive with holes in them: *turn her back; do not let her near the deep galleries; do
-not ask why.* Their loyalty is the campaign's real stat, and the dramatic irony runs the whole
-arc — the player works it out long before the character is permitted to.
+Orders arrive with holes in them: *keep her happy; keep her out of the deep galleries; do not ask
+why.* Their loyalty is the campaign's real stat, and the dramatic irony runs the whole arc — the
+player works it out long before the character is permitted to.
 
 Each Fixer needs: race, class, why they fled the Kazhrun, and what they owe Drakmoor.
 
 ### 6.2 The situation
 
-A cleric of Ehrendil Beldroth has reached the pass. She felt something from a hundred miles
-away that should not be there, and she has walked to the edge of the world to find out what.
+**Thekla Morvani walks into Gobtown.** She did not follow a map — a Prevaricator follows tales,
+and a rumour of a chief who makes tribes cooperate was too good to ignore. She came to see
+whether the story is true.
 
-The party must turn her back **without killing her** — a dead Ehrendil cleric in the north
-brings Valdenmark — and **without letting her near the water**, because she will know it on
-sight.
+**Why they cannot simply eat her.** Two reasons, both native to goblinoid culture:
 
-Every available tool is a different kind of failure: lying invites her to stay and investigate
-the inconsistencies; robbing her leaves a victim who reports; frightening her confirms there
-is something to hide. And the worst complication is that she is **genuinely kind to them**,
-treats them as people, thanks them for the food — and they have no idea what to do about that.
-The Concord is, quietly, making them worse at being hostile to her.
+1. She is clergy of Vykthar, whose doctrine holds that goblinoid deeds deserve proper telling and
+   who "favors those who refuse to let their people be dismissed as worthless." Killing her is
+   sacrilege against a goddess whose favour every warrior in that cave wants.
+2. More powerfully: **she decides whether Gobtown becomes a legend or is forgotten.** To a people
+   whose second virtue is bragging rights, the storyteller is the most powerful visitor they will
+   ever receive. Eating her means the greatest thing any gobbo has ever done goes untold — which
+   is worse than death, and every resident knows it.
 
-### 6.3 Resolutions
+**The inverted threat vector.** The secret does not leak through spycraft. It leaks through
+**vanity**. Everyone in Gobtown wants to be in the story. The Fixers' job is not to keep her out —
+she is an honoured guest — but to manage what three hundred people tell her while she is inside.
+Every gobbo they silence is incandescent about being left out of the tale of the age. *That* is
+the pressure, and it is generated entirely by goblinoid values.
 
-- **Pyrrhic:** she leaves convinced, and tells someone about the surprisingly decent goblins.
-- **Compromise:** she is escorted out believing the settlement is a mining camp; a clock starts.
-- **Spectacular failure:** she reaches the water.
-- **Surprising success:** she leaves knowing exactly what is down there, and decides — for her
-  own reasons — to say nothing. She becomes the party's most dangerous asset.
+### 6.3 Is she spying?
+
+Three loyalties, and the best version is that **she has not resolved it either**:
+
+- **Duke Kessarin** sent her to assess whether this settlement is a threat.
+- **Vykthar** obliges her to carry a tale this good back to the campfires.
+- **The Truthkeepers** — the cult's secret strand, who "maintain secret libraries in ruins,
+  caves, and abandoned settlements… posing as simple storytellers while gathering evidence" —
+  would have her *archive* Gobtown rather than report it. Preserve the history; publish nothing.
+
+Drakmoor cannot tell which. Neither can the party. Possibly neither can she.
+
+### 6.4 Resolutions
+
+- **Pyrrhic:** she leaves with a story that makes Gobtown legendary — and therefore findable.
+- **Compromise:** she leaves believing it is a mining camp, and a different clock starts.
+- **Spectacular failure:** someone brags about the deep water, and she goes looking.
+- **Surprising success:** she works it out, and chooses to archive rather than publish. She
+  becomes the party's most dangerous asset — and Drakmoor is denied the fame he craves, by a
+  woman protecting him from it.
+
+### 6.5 Later, and bluntly
+
+The Ehrendil cleric from rev. 1 remains a valid *discovery vector* but is not this scenario. If
+one arrives, the gobbos kill and eat her, exactly as they should. What that generates is a
+missing cleric and the search party that follows — a blunter, later problem.
 
 ---
 
@@ -335,36 +435,40 @@ The Concord is, quietly, making them worse at being hostile to her.
 
 Target: `myth-campaign-f0745885c38a` in `alh_mythras`.
 
-1. **Switch system flag** from `mythras` to `classic-fantasy` (direct TypeDB attribute edit;
-   `create-campaign` sets it but no update command exists). Enables the 348-piece CFI rules
-   graph for this campaign.
-2. **Rewind era** — game date to year eight of the settlement; opening scene set to the Fixers
-   receiving an order with holes in it.
-3. **Relabel Year 12 material** — existing lore, NPCs, factions, and locations get a
-   founding-era note marking them as future canon, not present. No deletions.
-4. **New lore entries** — the Kazhrun, Valdenmark, Khorvenn, the Wellspring (gm), the Concord
-   with its decay clock (gm), Thekla's narrator frame, the six races, half-breed rules, the two
-   culture packages, the five virtues, the alignment rider.
-5. **New NPCs** — founding-era Drakmoor (exhausted, ~50, Lawful Evil drifting); the angel;
-   Thekla Morvani; Duke Aldric Kessarin; a traditionalist ringleader agitating for a return to
-   raiding; the pilgrim.
+1. **Switch system flag** `mythras` → `classic-fantasy` (direct TypeDB attribute edit; no update
+   command exists). Enables the CFI rules graph for this campaign.
+2. **Rewind era** — game date to year eight; opening scene: the Fixers receiving an order with
+   holes in it, hours before Thekla arrives.
+3. **Relabel Year 12 material** — existing lore, NPCs, factions, locations get a founding-era note
+   marking them future canon. No deletions.
+4. **New lore** — the Kazhrun, Valdenmark, Khorvenn, the Wellspring (gm), the Concord + decay
+   clock (gm), Thekla's narrator frame, the four races + two variants, half-breed rules, the
+   conversion methodology, both culture packages, the five virtues, the alignment rider.
+5. **New NPCs** — founding-era Drakmoor (~50, exhausted, Lawful Evil drifting); the angel; Thekla
+   Morvani (half-orc); Duke Aldric Kessarin; a traditionalist ringleader.
 6. **New factions** — the surviving Ironspear, the traditionalists, Valdenmark, the Kazhrun
    tribes, the mixed-heritage settlers.
-7. **Scenario entry** — "The Pilgrim" as gm-visibility lore.
+7. **Scenario** — "The Emissary" as gm-visibility lore.
+8. **Templates** — spawnable stat blocks for goblin/hobgoblin/orc/bugbear using the real
+   Chapter 11 numbers, replacing the invented ones seeded on 2026-07-25.
 
 ---
 
 ## 8. Open questions
 
-1. **Population ceiling.** The prior draft's instinct was 300–400 for a settlement that must
-   stay hidden. Remoteness argues for the low end. Needs a number before the scenario is run.
+1. **Population ceiling.** Prior instinct was 300–400 for a settlement that must stay hidden;
+   remoteness argues for the low end. Needs a number before "The Emissary" is run.
 2. **Who carved Khorvenn?** The caves predate Drakmoor. Either Ehrendil placed the spirit in
-   anticipation, or it is a much older site repurposed — the second is more interesting and
-   raises the question of who cut the musical notation into the walls.
+   anticipation, or it is a much older site repurposed — the second is more interesting and asks
+   who cut the musical notation into the walls.
 3. **Cult politics.** Vykthar's myth-making, Velthara's theft-as-art, and Razak's systematic
    pillage all have opinions about a settlement that has stopped raiding. Gobtown should be
    theologically contested; that is a chapter in itself.
-4. **Does the angel have a name?** It has a voice and comic timing but no name in any source
-   document. It may refuse to give one, which is characterful.
-5. **Proxy names** are provisional. Kazhrun, Valdenmark, Kessarin, and Khorvenn can all be
-   swapped at no cost before the lore is written.
+4. **Does the angel have a name?** It has a voice and comic timing but no name in any source. It
+   may refuse to give one, which is characterful.
+5. **Orog derived attributes.** The book prints no averages for the overridden characteristics and
+   says orogs are "treated in all other ways as orcs" — leaving it ambiguous whether Damage
+   Modifier, Action Points and hit-point totals should be recomputed from the higher values. House
+   ruling needed; recomputing is the defensible reading.
+6. **Proxy names** remain provisional. Kazhrun, Valdenmark, Kessarin, Khorvenn all swappable at no
+   cost until the lore is written.

--- a/docs/superpowers/specs/2026-07-26-gobtown-origins-design.md
+++ b/docs/superpowers/specs/2026-07-26-gobtown-origins-design.md
@@ -397,7 +397,7 @@ Full CF class list applies. See parent spec §5 for the mapping and the two new 
 | Cleric | priest, shaman, Prevaricator (Vykthar — pending, parent §5.2) |
 | Magic-User | hedge-wizard, alchemist, ritualist |
 | Bard | entertainer, jester, boast-singer |
-| **Wolf Rider** 🆕 | beast handler — *a Kazhrun class, near-useless in Khorvenn's tunnels* |
+| **Wolf Rider** 🆕 | outrider — holds the approaches; the reason Gobtown has not been found |
 | **Crafter / Miner** 🆕 | *the Gobtown class; barely exists in the tribal lands* |
 
 **Closed to goblinoids:** Paladin (Lawful Good unreachable) and Druid, per the book's own note;

--- a/docs/superpowers/specs/2026-07-26-gobtown-origins-design.md
+++ b/docs/superpowers/specs/2026-07-26-gobtown-origins-design.md
@@ -198,13 +198,18 @@ table in rev. 1 entirely.**
 | DEX | 4d6 (14) | 3d6 (11) | 3d6 (11) | 3d6 (11) |
 | INT | 2d6+5 (12) | 2d6+6 (13) | 2d6+4 (11) | 2d6+3 (10) |
 | POW | 3d6 (11) | 3d6 (11) | 3d6 (11) | 3d6 (11) |
-| CHA | 2d6 (7) | 2d6 (7) | 2d6 (7) | 2d6 (7) |
+| CHA | **3d6 (11)** | **3d6 (11)** | **3d6 (11)** | **3d6 (11)** |
 | Damage Mod | −1d2 | +1d2 | +1d2 | +1d6 |
 | Movement | 15 ft | 15 ft | 20 ft | 15 ft |
 | Lifespan | ~50 yrs | ~60 yrs | ~40 yrs | not given |
 | Traits | Darkvision, **Light Sensitive** | Darkvision, **Tunnel Sense** | Darkvision, **Light Sensitive** | Darkvision |
 
-Every goblinoid shares POW `3d6 (11)` and CHA `2d6 (7)`. Magic Points 11 across the board.
+Every goblinoid shares POW `3d6 (11)`. Magic Points 11 across the board.
+
+> **CHA is re-baselined from the printed `2d6`** — see parent spec §5A. Goblinoid CHA is `3d6`,
+> with a symmetric **−4 when dealing with any culture not your own**, which reproduces the printed
+> `2d6 (7)` exactly as seen from outside. In Gobtown, among their own, these are articulate and
+> funny people; the moment Thekla or a Valdenmark surveyor walks in, they are not.
 
 **Variants, written as deltas exactly as the book writes them:**
 

--- a/docs/superpowers/specs/2026-07-26-gobtown-origins-design.md
+++ b/docs/superpowers/specs/2026-07-26-gobtown-origins-design.md
@@ -150,6 +150,88 @@ Within Gobtown:
 
 Players feel the divine presence through their own dice long before anyone explains it.
 
+### 4.5 What the Concord actually buys — the Standing, and the Tithe
+
+The harmony is usually described in domestic terms: food shared, guards alert, nobody knifed over
+grain. Its largest effect is military, and it is the thing Drakmoor originally dreamed of.
+
+#### The problem it solves
+
+His founding insight was arithmetic. Goblinoid martial superiority means nothing when more energy
+goes into fighting each other than the enemy. Individual tribes are formidable; **no tribe can
+sustain a coordinated campaign.** Warbands rout when the leader falls, break off mid-fight to loot,
+refuse orders from another species, and abandon their wounded as a matter of course.
+
+A Concord-affected force does none of that.
+
+#### The Standing
+
+The military expression of the Concord. Applies to units composed of Gobtown residents:
+
+- **No mid-fight looting.** The most reliable way to beat a goblinoid warband is to drop something
+  shiny in front of it. Gobtown units do not break off.
+- **Cross-species orders are obeyed.** A goblin sergeant is followed by orcs. In the Kazhrun this
+  is not merely rare, it is unheard of.
+- **Morale.** Willpower rolls to resist rout run **one grade easier**, and a unit that loses its
+  commander does not disintegrate — someone else picks it up.
+- **The wounded come home.** Goblinoids do not retrieve casualties. Gobtown does, and the effect
+  compounds: veterans accumulate instead of being spent.
+
+Mechanically, treat a Gobtown unit as possessing formation training plus the standard Concord
+augment on coordinated actions.
+
+**Strategic consequence: Gobtown's twenty-odd fighting adults are worth a Kazhrun warband of a
+hundred.** This is how a settlement of fifty to a hundred souls holds a pass at all, and the GM
+should let the players discover it by watching a fight go inexplicably well.
+
+#### The Tithe — restraint in raiding
+
+They do raid. Minimally, far from home, and under a doctrine Drakmoor received as advice and
+implemented as law:
+
+1. **Take a third.** Leave the rest, and leave the place *working*.
+2. **Leave no witness who saw a goblinoid.** Witnesses are acceptable — provided they saw bandits.
+3. **Never the same target twice in living memory**, and never within four days' travel of the pass.
+4. **No burning.** Fire is a signal that carries for thirty miles.
+
+Where the Kazhrun tribes strip-mine, Gobtown **farms**. A village raided under the Tithe recovers
+and is worth visiting again in a decade; a village hit by a Kazhrun warband is a ruin, a grudge and
+a punitive expedition. Over eight years the difference compounds into the settlement's entire
+economy — and into the fact that nobody is looking for them.
+
+#### The trap
+
+**This is the single most likely thing to expose Gobtown, and it is a virtue.**
+
+A warband that does not loot is not a warband. Discipline is *evidence*. A Valdenmark officer who
+files an unremarkable report — *they withdrew in good order, carried their wounded off, took a
+portion of the grain and burned nothing* — has described something impossible without knowing it.
+And Thekla Morvani, who has spent six years explaining to a duke exactly what goblinoid raiders do,
+would read that report in a heartbeat.
+
+The Wellspring's best-hidden secret is not in the deep chamber. It is in the paperwork.
+
+#### Drakmoor got precisely what he asked for
+
+His dreams in the singing caves were of goblinoid tribes moving in coordination, strength
+supporting cunning supporting strategy, unified forces that could build or crush. **He has built
+exactly that, in miniature, and can never deploy it** — because using the army reveals the army.
+The angel handed him the thing he wanted most and made it unusable, and it is not clear even to the
+angel whether that was mercy or method.
+
+#### And Ghazrek can see it
+
+He commands the best-drilled goblinoid force in the history of the Kazhrun, and he wants the old
+ways back. His pride and his grievance are the same fact seen from two sides, and he has never
+put the contradiction into words because doing so would require conceding that the new way works.
+
+**Note the fault line, though.** His outriders are the least-dosed members of the settlement
+(§5C.2a in the supplement spec) — so the unit that meets every stranger *first* is the one least
+reliably bound by the Standing. The first outsiders to encounter Gobtown will meet its worst-
+disciplined troops, commanded by the man least invested in restraint, several days' ride from the
+water that would have made them behave.
+
+
 ### 4.4 Discovery vectors
 
 - A cleric of Ehrendil senses **one** presence, unmistakably, at considerable range.

--- a/docs/superpowers/specs/2026-07-26-gobtown-origins-design.md
+++ b/docs/superpowers/specs/2026-07-26-gobtown-origins-design.md
@@ -218,10 +218,33 @@ Every goblinoid shares POW `3d6 (11)` and CHA `2d6 (7)`. Magic Points 11 across 
   traits, Swim 66%, and 20 ft underwater movement. *A Koolinth PC is mechanically a hobgoblin
   who can swim into the Wellspring.*
 - **Orog** — variant of **Orc** ("great orcs", 6–6½ ft, possibly part ogre). Overrides STR
-  `2d6+10`, CON `3d6+6`, SIZ `1d6+12`, DEX `2d6+2` (**the book prints no averages for these — do
-  not compute them into the Points Build column without flagging**); +10% to Athletics, Brawn,
-  Endurance, Unarmed and Combat Style; 2 points of tough skin. "Treated in all other ways as
-  orcs." Rare — roughly one per ten orc warriors.
+  `2d6+10`, CON `3d6+6`, SIZ `1d6+12`, DEX `2d6+2` (averages 17 / 17 / 16 / 9, rounding the half
+  up as the book does for Hobgoblin CON and SIZ); INT, POW and CHA inherited from Orc; +10% to
+  Athletics, Brawn, Endurance, Unarmed and Combat Style; 2 points of tough skin **on top of**
+  worn armour. Rare — roughly one per ten orc warriors.
+
+  **Derived attributes must be recomputed**, because Damage Modifier reads off STR+SIZ and hit
+  points off CON+SIZ, and the variant changes all three. "Treated in all other ways as orcs"
+  governs the non-derived material. Verified: the derivation reproduces every printed Damage
+  Modifier and Action Point value for all six statted goblinoids exactly.
+
+  | | Orc | Orog | |
+  |---|---|---|---|
+  | STR+SIZ | 28 | **33** | |
+  | Damage Modifier | +1d2 | **+1d4** | one step up |
+  | CON+SIZ | 27 | **33** | |
+  | HP — Head / Chest / Abdomen / Arm / Leg | 6 / 8 / 7 / 5 / 6 | **7 / 9 / 8 / 6 / 7** | +1 per location |
+  | DEX+INT | 22 | 20 | |
+  | Action Points | 2 | **2** | unchanged |
+  | Initiative (DEX+INT)/2 | 11 | **10** | *one slower* |
+  | Magic Points (POW) | 11 | 11 | unchanged |
+
+  The initiative drop matters: an orog is stronger, tougher and harder to kill, but **acts
+  later** than a common orc. That is a genuine trade-off rather than a straight upgrade, and it
+  is worth playing up — orogs hit like a falling rock and are always half a beat behind.
+
+  *Rounding note:* if the half-points rounded down instead (CON 16, SIZ 15), both results are
+  unchanged — STR+SIZ 32 is still +1d4 and CON+SIZ 31 is still the same HP column.
 
 ### 5.4 Half-breeds and mixed heritage
 
@@ -505,9 +528,8 @@ Target: `myth-campaign-f0745885c38a` in `alh_mythras`.
    theologically contested; that is a chapter in itself.
 4. **Does the angel have a name?** It has a voice and comic timing but no name in any source. It
    may refuse to give one, which is characterful.
-5. **Orog derived attributes.** The book prints no averages for the overridden characteristics and
-   says orogs are "treated in all other ways as orcs" — leaving it ambiguous whether Damage
-   Modifier, Action Points and hit-point totals should be recomputed from the higher values. House
-   ruling needed; recomputing is the defensible reading.
+5. ~~**Orog derived attributes.**~~ **Resolved** — not a house ruling. Damage Modifier derives
+   from STR+SIZ and hit points from CON+SIZ, so overriding those characteristics necessarily
+   changes both. Recomputed in §5.3 and validated against all six printed goblinoid stat blocks.
 6. **Proxy names** remain provisional. Kazhrun, Valdenmark, Kessarin, Khorvenn all swappable at no
    cost until the lore is written.

--- a/docs/superpowers/specs/2026-07-26-gobtown-origins-design.md
+++ b/docs/superpowers/specs/2026-07-26-gobtown-origins-design.md
@@ -1,0 +1,370 @@
+# Gobtown: Founding Era — Design Spec
+
+**Date:** 2026-07-26
+**Campaign:** `goblinpak` — `myth-campaign-f0745885c38a` (TypeDB `alh_mythras`)
+**System:** Mythras Classic Fantasy Imperative (CFI)
+**Status:** Draft for review
+
+---
+
+## 1. Premise
+
+GoblinPack is a Classic Fantasy supplement in which goblinoids are protagonists rather than
+battle-fodder. This spec covers the **founding era** of Gobtown: a settlement roughly eight
+years old, a few hundred souls in a cave network in a remote northern pass, which everyone
+including most of its own residents expects to fail.
+
+The design thesis, from Haidt's moral foundations work: goblinoids are not immoral, they
+weight the foundations differently. They are "evil" the way a foreign culture is evil to a
+xenophobe — legibly, consistently, with internal logic about who deserves what.
+
+**Tribal hatred is contextual, not innate.** Two warbands competing for one valley have
+excellent reasons to slaughter each other; the same two under a competent captain may not.
+How hate-filled a group is depends on leadership, scarcity, and history — not species.
+
+**The Evil passion is not psychopathy.** Pre-modern humans enjoyed public executions without
+being unable to love their children. Cruelty is a spectator taste and a tool, directed by
+cultural rules about who is fair game. This distinction is load-bearing; see §5.5.
+
+### Scope boundary
+
+This spec covers the founding era only. The present-day Year 12 material already in the
+database (the full city, the Accords, the inner circle) is retained as GM-visibility
+*future canon* — it tells the GM what is at stake, and is not playable content here.
+
+---
+
+## 2. Canon boundaries
+
+Greymyr setting material is under NDA and has **not** been read. Nothing in this spec derives
+from it. The proxy policy:
+
+| Keep (published TDM pantheon / user's own work) | Proxy (Greymyr gazetteer) |
+|---|---|
+| Ehrendil Beldroth — elven god of music and creation | the mountain range |
+| Garex Blood-Drinker, Grumash, Thaogg Axefang, Zulfang | the human realm |
+| The user's cults: Vykthar, Velthara, Grottendacz, Mawhunger Gnawbone, Khorthak, Sniktch, Razak, Skarrak | the duke |
+| Drakmoor, the Ironspear Clan, Thekla Morvani, Gobtown | any named site from the manuscripts |
+
+**Coined proxy names** (cheap to change; all follow the stated rule that descriptive elements
+should be titles rather than surnames):
+
+- **The Kazhrun** — the mountain spine east of human lands; goblinoid heartland, permanently
+  at war with itself, no institution outliving the chief who founded it. Humans call it the
+  Eastern Wall.
+- **The Duchy of Valdenmark** — the human realm to the west. Wealthy, hostile to goblinoids,
+  under low-grade pressure from Kazhrun raiding.
+- **Duke Aldric Kessarin** — its ruler; advised on goblinoid matters by Thekla Morvani.
+- **Khorvenn**, *the humming* — the cave system Gobtown grows inside.
+
+Location is deliberately loose: a high pass at the cold northern end of the Kazhrun, outside
+the tribal lands, reachable only by routes that kill the careless. **Remoteness is the city's
+first wall** and the reason a secret this large can be kept at all.
+
+---
+
+## 3. Thekla Morvani as narrator
+
+Thekla Morvani, Grand Prevaricator of Vykthar, advisor on goblinoid matters to Duke Aldric
+Kessarin, narrates the supplement. Each chapter is framed by her commentary.
+
+A Grand Prevaricator is a professional myth-maker. This makes the narrator **unreliable by
+doctrine**: she is not neutrally describing goblinoid society, she is selling it to a hostile
+human court, and every framing is an act of advocacy by a priestess whose goddess rewards the
+tale told well.
+
+**Thekla does not know about the Wellspring.** (Decided 2026-07-26.) Her narration is honest
+as far as it goes; she is arguing for goblinoid complexity from evidence, not protecting a
+secret. Her eventual discovery of what actually underwrites Gobtown is therefore a real event
+with real consequences for her position, her faith, and her patron.
+
+Her established voice, from the v0 draft:
+
+> "Your Grace — it might be wiser to stop thinking of your adversaries in the mountains as
+> just chaotic and 'evil.' It is true that they want nothing more in life than to wade
+> through the blood of your countrymen... But you must also remember that the only reason
+> they would contemplate these actions is that it would make a fantastic drinking song.
+> Please… at least try to see it from their point of view."
+
+---
+
+## 4. The Wellspring
+
+### 4.1 What it is
+
+In the deepest chamber of Khorvenn, a natural cathedral of stone holds a pool that sings.
+Bound in chains of crystallised song is an angelic spirit of Ehrendil Beldroth — and the
+spring and the spirit are **one entity, two aspects**. The water is the angel's presence made
+physical. Ancient carvings cover the approach: spiralling patterns that shift in torchlight,
+musical notation in an unreadable script. Objects left overnight are found arranged in
+geometric patterns by morning.
+
+The water carries the harmony through the settlement — drunk, bathed in, irrigating the fungus
+beds. This answers the standing question of how a hidden cave feeds several hundred people:
+**it feeds them because the god is in the water.** Cutting the water is cutting the god.
+
+### 4.2 The four-layer irony
+
+| Party | Believes |
+|---|---|
+| Drakmoor | He captured and bound a celestial being and forces it to serve. Daily ritual maintains the binding. |
+| The angel | It was assigned by cosmic bureaucracy to a degrading rehabilitation project among creatures it finds crude and aesthetically offensive. It suffers from the company, not the chains — and is personally insulted that second-rate goblin hedge-wizards imagine their ritual could hold it. (It could leave at any time. It has not mentioned this.) |
+| Ehrendil Beldroth | Goblinoids are part of creation and currently outside the Song. They cannot be commanded into harmony without destroying what makes them themselves. So they must be brought in through their own cunning and self-interest — offered civilisation as a prize they think they stole. |
+| Everyone else | Will be horrified on discovery, and will not understand what they are looking at. |
+
+The binding ritual is theatre. It is also a daily meditation that gradually attunes Drakmoor
+to reciprocity, deferred gratification, and mutual benefit. The angel's grudging advice
+consistently steers him toward solutions that strengthen the community rather than his grip.
+
+### 4.3 The Concord (mechanics)
+
+The harmony has a real mechanical footprint. Within Gobtown:
+
+- Cooperative actions (assisting, coordinated effort, shared labour) gain an **augment**.
+- Inter-species friction checks run **one difficulty grade easier**.
+- Passions pulling toward communal benefit **deepen** faster than normal; passions pulling
+  toward predation on fellow settlers **wane** faster. (Uses `cfi/alignment/deepening-waning`.)
+
+**The decay clock.** If the dawn ritual is missed, the Concord degrades visibly:
+
+| Elapsed | Effect |
+|---|---|
+| Day 1 | Augment lost. Bickering, old grudges resurface. |
+| Day 2 | Friction checks return to normal grade. Hoarding begins; shared stores are raided. |
+| Day 3 | Friction checks one grade *harder* than baseline. Knives. |
+| Day 4+ | The settlement begins to disassemble along tribal lines. |
+
+This makes "keep the chief alive and on schedule" a live playable pressure, and lets players
+feel the divine presence through their own dice long before anyone explains it.
+
+### 4.4 Discovery vectors
+
+- A cleric of Ehrendil senses **one** presence, unmistakably, at considerable range.
+- The water tastes wrong to anyone who has drunk from a real spring.
+- Anyone who follows wet stone downhill far enough arrives.
+- **Koolinth can enter the pool.** They are the only settlers who can physically swim in the
+  god. This is a standing risk and a standing story opportunity — see §5.2.
+
+---
+
+## 5. Character generation
+
+### 5.1 The structural key: Race vs Culture
+
+CFI Step 5 separates **Race** (physiology: characteristic dice, darkvision, movement,
+lifespan) from **Culture** (skill package, alignment, passions — what you were raised into).
+
+In year eight, **Gobtown culture does not exist yet.** Every adult in the caves was raised in
+the Kazhrun. Every PC therefore arrives with tribal skills, tribal passions, and tribal
+instincts about who is fair game — all wrong for the place they now live. The friction between
+what the character was raised to be and what the settlement needs is not colour text; it is
+on the sheet, and it is the campaign.
+
+Two culture packages are written. Only one is available.
+
+### 5.2 Races
+
+Characteristic dice follow the CFI Racial Characteristics Table format. Averages in
+parentheses are used for Points Build.
+
+| Stat | Goblin | Hobgoblin | Orc | Bugbear | Koolinth | Orog |
+|:--|:--:|:--:|:--:|:--:|:--:|:--:|
+| STR | 2d6+1 (8) | 2d6+6 (13) | 2d6+8 (15) | 2d6+12 (19) | 2d6+5 (12) | 2d6+9 (16) |
+| CON | 3d6 (11) | 2d6+6 (13) | 2d6+6 (13) | 2d6+7 (14) | 2d6+7 (14) | 2d6+8 (15) |
+| SIZ | 1d4+5 (8) | 2d6+6 (13) | 2d6+6 (13) | 2d6+14 (21) | 2d6+5 (12) | 2d6+7 (14) |
+| DEX | 2d6+7 (14) | 3d6 (11) | 3d6 (11) | 3d6 (11) | 2d6+5 (12) | 3d6 (11) |
+| INT | 2d6+5 (12) | 2d6+6 (13) | 2d6+4 (11) | 2d6+3 (10) | 2d6+5 (12) | 2d6+6 (13) |
+| POW | 3d6 (11) | 3d6 (11) | 3d6 (11) | 3d6 (11) | 3d6 (11) | 3d6 (11) |
+| CHA | 2d6 (7) | 2d6+3 (10) | 2d6+1 (8) | 2d6+1 (8) | 2d6+2 (9) | 2d6+2 (9) |
+
+**Common to all goblinoids:** Darkvision 60 ft (as CFI Half-Orc). Illiterate unless raised in
+a literate culture. Additional languages limited to goblin, hobgoblin, orc, and gnoll.
+
+**Per-race special rules:**
+
+- **Goblin** — Movement 20 ft. *Light sensitivity*: Perception and ranged attacks one grade
+  harder in full daylight. Lifespan ~50. Most likely of all goblinoids to be literate; a
+  Goblin may take literacy at creation without the Experience Roll cost.
+- **Hobgoblin** — Movement 25 ft. *Thick hide*: natural 1 AP on all locations. **No light
+  sensitivity.** Lifespan ~60. Natural officers; other goblinoids expect them to command.
+- **Orc** — Movement 25 ft. Light sensitivity as Goblin. Lifespan ~40 — the shortest, and it
+  shapes the psychology: an orc of thirty is old and knows it.
+- **Bugbear** — Movement 25 ft. **No light sensitivity.** *Scent*: Perception by smell one
+  grade easier. Their SIZ makes some cave galleries impassable — a real constraint in Khorvenn
+  and a running joke.
+- **Koolinth** — Movement 20 ft land / 30 ft swim. *Amphibious*: breathes water indefinitely;
+  Swim base doubled. Suffers in dry heat (Endurance one grade harder). **Can enter the
+  Wellspring pool.** In a settlement built on a sacred spring this is enormous: a Koolinth PC
+  can go where Drakmoor cannot follow.
+- **Orog** — Movement 25 ft. *Thick hide*: natural 1 AP. Darkvision 90 ft (deep-dwelling), but
+  light sensitivity is **severe** — two grades harder in full daylight. Disciplined and
+  markedly smarter than common orcs, which common orcs resent.
+
+### 5.3 Half-breeds and mixed heritage
+
+Orcs, per the source material, "will breed with anything," and half-breeds are common
+throughout the Kazhrun. Crucially: **a half-breed belongs to no clan.** In tribal society this
+is a permanent disqualification from status, protection, and inheritance.
+
+Which is exactly why they came. The people with no tribe are the first to arrive at a place
+that does not ask what tribe you are from. **Mixed-heritage characters are a disproportionate
+share of founding-era Gobtown, and are a large part of why the settlement cohered at all.**
+This is the historical root of the Mixed District that dominates the Year 12 city.
+
+- **Half-Orc** — use the CFI Half-Orc entry as printed. Add the Gobtown note: a half-orc raised
+  among orcs takes the Kazhrun Tribal culture below rather than a human culture.
+- **Goblinoid mixed heritage** (orc×goblin, hobgoblin×orc, bugbear×hobgoblin, etc.) — choose
+  two parent races. For each characteristic, average the two parents' **table averages**
+  (rounding down) and express the result as `2d6+N` where N = average − 7; if that average is
+  7 or less, use `2d6`. Working from the averages rather than the dice expressions avoids the
+  problem that parents may roll different dice entirely (Goblin SIZ is `1d4+5`, Orc SIZ is
+  `2d6+6`). *Example — Orc × Goblin:* STR (15+8)/2 = 11 → `2d6+4`; SIZ (13+8)/2 = 10 →
+  `2d6+3`. Take darkvision from the better parent, light sensitivity from the worse, and
+  movement from the smaller. Choose one parent's special rule; the other is lost.
+- **Passion, all mixed heritage:** *No Clan Will Have Me* — starts at the standard passion
+  value. It augments any roll to survive alone, endure contempt, or make common cause with
+  another outcast. In Gobtown, and only in Gobtown, it begins to wane.
+
+### 5.4 Culture packages
+
+**Kazhrun Tribal** *(available — this is what everyone has)*
+
+- Free skills: Customs (Kazhrun) +40, Native Tongue +40
+- Standard: Athletics, Brawn, Endurance, Evade, Perception, Stealth, plus one of Ride or Swim
+- Professional: Craft (any), Intimidation, Survival, Track, plus one of Healing or Navigate
+- Illiterate. Passions from the tribal menu (§5.5). Alignment typically Chaotic Evil;
+  hobgoblins and orogs typically Lawful Evil.
+
+**Gobtown-Born** *(written, but NOT available at character creation)*
+
+Requires being raised in the settlement from early childhood. In year eight the oldest
+qualifying child is seven years old. No PC can take this package. It is printed so players can
+read the future they are building, and **the first child to come of age with it is a campaign
+milestone.**
+
+- Free skills: Customs (Gobtown) +40, Native Tongue +40, Language (one other goblinoid) +40
+- Standard: Athletics, Deceit, Endurance, Influence, Insight, Locale, Perception
+- Professional: Commerce, Craft (any), Engineering, Lore (any), Streetwise
+- **Literate.** Passions drawn from a different menu entirely: *This Place Must Not Fail*,
+  *My Neighbour Is Not Meat*, *I Have Never Seen The Sky And I Am Fine*.
+
+### 5.5 Passions — the five virtues
+
+The five goblinoid virtues become the standard tribal passion menu. Starting values per
+`cfi/alignment/passion-table`. Each augments rolls taken in accordance with it.
+
+| Passion | Augments |
+|---|---|
+| *Shut Up And Get On With It* | Enduring hardship without complaint; completing a task under pressure; refusing to be delayed by ceremony, rank, or feelings |
+| *Be The Biggest Bastard You Can* | Intimidation; claiming credit; any act that deters future challenges |
+| *Extra Points For Comedy Value* | Any action that is both effective and humiliating to the target; improvised cruelty with an audience |
+| *Don't Be A Picky Eater* | Resisting disgust, poison, spoiled food, or starvation; making use of what others discard |
+| *Everyone Hates Us* | Acting against the smug and self-declared righteous; resisting Influence from other races |
+
+**The Concord's effect:** *Be The Biggest Bastard* and *Extra Points For Comedy Value* wane
+when their targets are fellow settlers, because the Concord has quietly redrawn who is fair
+game. Players will notice their passions sliding and will not be told why.
+
+### 5.6 The alignment rider
+
+Goblinoid PCs are Evil. The Concord does not make anyone Good — it **redraws the boundary of
+who counts as fair game** to include fellow settlers.
+
+A Gobtown goblin is still Evil by any Valdenmark cleric's reckoning: cruel to outsiders,
+contemptuous of weakness, delighted by others' misfortune. He simply does not rob his
+neighbours any more, and **could not tell you why not.** That is the angel's work expressed as
+an alignment rule, and it is the single most important mechanical statement in this document.
+
+Ethical axis drifts Lawful under the Concord. Drakmoor is Lawful Evil and drifting further —
+which he experiences as exhaustion.
+
+### 5.7 Classes
+
+CFI's four classes carry the v0 concept list as goblinoid re-skins:
+
+| CFI class | Goblinoid expressions |
+|---|---|
+| Fighter | warrior, wolf-rider, beast handler, pit-fighter |
+| Rogue | sneak, agent, hunter, scout, acrobat |
+| Cleric | priest, shaman, prevaricator (Vykthar) |
+| Magic-User | hedge-wizard, alchemist, ritualist |
+
+Merchant/crafter/miner concepts are Professional skill loadouts, not separate classes.
+
+**Restriction:** no PC may be a cleric of Ehrendil Beldroth. Obviously.
+
+---
+
+## 6. The scenario: "The Pilgrim"
+
+### 6.1 The party — the Fixers
+
+PCs are trusted early settlers, Drakmoor's problem-solvers, **deliberately kept ignorant.**
+Orders arrive with holes in them: *turn her back; do not let her near the deep galleries; do
+not ask why.* Their loyalty is the campaign's real stat, and the dramatic irony runs the whole
+arc — the player works it out long before the character is permitted to.
+
+Each Fixer needs: race, class, why they fled the Kazhrun, and what they owe Drakmoor.
+
+### 6.2 The situation
+
+A cleric of Ehrendil Beldroth has reached the pass. She felt something from a hundred miles
+away that should not be there, and she has walked to the edge of the world to find out what.
+
+The party must turn her back **without killing her** — a dead Ehrendil cleric in the north
+brings Valdenmark — and **without letting her near the water**, because she will know it on
+sight.
+
+Every available tool is a different kind of failure: lying invites her to stay and investigate
+the inconsistencies; robbing her leaves a victim who reports; frightening her confirms there
+is something to hide. And the worst complication is that she is **genuinely kind to them**,
+treats them as people, thanks them for the food — and they have no idea what to do about that.
+The Concord is, quietly, making them worse at being hostile to her.
+
+### 6.3 Resolutions
+
+- **Pyrrhic:** she leaves convinced, and tells someone about the surprisingly decent goblins.
+- **Compromise:** she is escorted out believing the settlement is a mining camp; a clock starts.
+- **Spectacular failure:** she reaches the water.
+- **Surprising success:** she leaves knowing exactly what is down there, and decides — for her
+  own reasons — to say nothing. She becomes the party's most dangerous asset.
+
+---
+
+## 7. Database plan
+
+Target: `myth-campaign-f0745885c38a` in `alh_mythras`.
+
+1. **Switch system flag** from `mythras` to `classic-fantasy` (direct TypeDB attribute edit;
+   `create-campaign` sets it but no update command exists). Enables the 348-piece CFI rules
+   graph for this campaign.
+2. **Rewind era** — game date to year eight of the settlement; opening scene set to the Fixers
+   receiving an order with holes in it.
+3. **Relabel Year 12 material** — existing lore, NPCs, factions, and locations get a
+   founding-era note marking them as future canon, not present. No deletions.
+4. **New lore entries** — the Kazhrun, Valdenmark, Khorvenn, the Wellspring (gm), the Concord
+   with its decay clock (gm), Thekla's narrator frame, the six races, half-breed rules, the two
+   culture packages, the five virtues, the alignment rider.
+5. **New NPCs** — founding-era Drakmoor (exhausted, ~50, Lawful Evil drifting); the angel;
+   Thekla Morvani; Duke Aldric Kessarin; a traditionalist ringleader agitating for a return to
+   raiding; the pilgrim.
+6. **New factions** — the surviving Ironspear, the traditionalists, Valdenmark, the Kazhrun
+   tribes, the mixed-heritage settlers.
+7. **Scenario entry** — "The Pilgrim" as gm-visibility lore.
+
+---
+
+## 8. Open questions
+
+1. **Population ceiling.** The prior draft's instinct was 300–400 for a settlement that must
+   stay hidden. Remoteness argues for the low end. Needs a number before the scenario is run.
+2. **Who carved Khorvenn?** The caves predate Drakmoor. Either Ehrendil placed the spirit in
+   anticipation, or it is a much older site repurposed — the second is more interesting and
+   raises the question of who cut the musical notation into the walls.
+3. **Cult politics.** Vykthar's myth-making, Velthara's theft-as-art, and Razak's systematic
+   pillage all have opinions about a settlement that has stopped raiding. Gobtown should be
+   theologically contested; that is a chapter in itself.
+4. **Does the angel have a name?** It has a voice and comic timing but no name in any source
+   document. It may refuse to give one, which is characterful.
+5. **Proxy names** are provisional. Kazhrun, Valdenmark, Kessarin, and Khorvenn can all be
+   swapped at no cost before the lore is written.


### PR DESCRIPTION
Design specs and campaign data for **GoblinPack**, a Mythras Classic Fantasy supplement in which goblinoids are protagonists rather than battle-fodder.

## What's here

**Two specs.** A supplement-level design doc built on the v0 table of contents with honest per-chapter status (most of it is *not* written, and the tracker says so), plus a chapter spec for the Gobtown founding era.

**System decision: full Classic Fantasy (TDM500), not the Imperative SRD.** The deciding evidence was the existing class list, which contains Bard and Thief-Acrobat — present in CF core, absent from CFI's four classes. Targeting CFI would have silently deleted two of eight archetypes.

**Race stats transcribed from the rulebook**, replacing invented numbers. Goblin, hobgoblin, orc and bugbear from Chapter 11; koolinth and orog written as delta variants exactly as the book writes them. The full extraction is cited with page/line references.

**A creature-to-PC-race conversion method.** No monster-PC subsystem exists in any of the four volumes — only one paragraph of permission pointing at the bestiary. The method here is recovered empirically from Orc → Half-Orc, the only species statted in both formats.

**The CHA re-baseline.** Across the six statted goblinoids, CHA is the only characteristic that is uniformly floored — STR spans 8–19, SIZ 8–21, INT 10–13, and every species collapses to an identical `2d6` CHA. That is a measurement taken from outside. Rule: goblinoid CHA is `3d6` with a symmetric −4 toward any culture not your own. `3d6` averages 11; less 4 is 7, exactly the printed value, so vanilla stat blocks remain true as an enemy experiences them. It also repairs the Experience Modifier band and Vykthar's previously unreachable CHA 14 prerequisite.

**Three class drafts** against the real CF template: the Prevaricator Order (a third bardic order beside the Arcane College and the Druidic Order), Wolf Rider, and Crafter/Miner — the last of which finally gives anti-craftsmanship a mechanism in *Fast and Filthy*.

## Database

Campaign `goblinpak` in `alh_mythras`, flag `classic-fantasy`, populated with 13 founding-era characters carrying CF single-axis Moral Philosophy and derived stats computed from validated tables. The 13 Year 12 NPCs are retained and tagged as future canon rather than deleted.

The Moral Philosophy column is the campaign told in one number: Ghazrek's is elevated and rising, Drakmoor's has collapsed from a base of 58 to 39 after eight years of daily ritual he does not understand is acting on him.

## Notes

No Greymyr manuscript material was read; the NDA-covered gazetteer is replaced throughout by coined proxies (Kazhrun, Valdenmark, Kessarin, Khorvenn), all of which remain cheap to change.

Also fixes unresolved merge-conflict markers in `.claude/settings.json` that made it invalid JSON — reported by `/doctor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qwQuES62brPyNFF9C9qdC